### PR TITLE
Allow same strains for all segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@ To string these together and update the `clades.tsv` file for new sequences and 
 
 `snakemake -s Snakefile.clades -p --cores 1 && snakemake -p --cores 1`
 
+### Using the same strains for all segments
+
+By default we subsample data for each segment independently.
+Alternatively, you can ask the pipeline to use the same strains for each segment.
+This modifies the pipeline in a few ways:
+1. An additional metadata processing step is added which counts the number of segments a strain has sequence data for
+2. Subsampling is performed as normal for the HA segment, with the additional condition that each sample has sequence data for all segments
+3. All other segments are subsampled to contain the same strains as used for HA in step 2
+
+To enable this set the config parameter `same_strains_per_segment` to a truthy value. If you are calling `snakemake` directly you can add
+
+    --config 'same_strains_per_segment=True'
+
+If you are using `nextstrain build` then add that to the end of the command (i.e. as a parameter which will be passed through to Snakemake).
+
+Note that you may need to remove any existing data in `results/` in order for snakemake to correctly regenerate the intermediate files.
+
 ## To modify this build to work with your own data
 Although the simplest way to generate a custom build is via the quickstart build, you are welcome to clone this repo and use it as a starting point for running your own, local builds if you'd like. The [Nextstrain docs](https://docs.nextstrain.org/en/latest/index.html) are a fantastic resource for getting started with the Nextstrain pipeline, and include some [great tutorials](https://docs.nextstrain.org/en/latest/install.html) to get you started. This build is slightly more complicated than other builds, and has a few custom functions in it to accommodate all the features on [nextstrain.org](https://nextstrain.org/flu/avian), and makes use of wildcards for both subtypes and gene segments. If you'd like to adapt this full, non-simplified pipeline here to your own data (which you may want to do if you also want to annotate clades), you would need to make a few changes and additions:
 

--- a/scripts/add_segment_counts.py
+++ b/scripts/add_segment_counts.py
@@ -1,0 +1,70 @@
+"""
+Takes in a set of metadata TSVs corresponding to segments (i.e. typically 8 TSVs)
+and adds a column to the input `--metadata` TSV with the number of segments
+that strain appears in.
+"""
+
+import argparse
+import csv
+from collections import defaultdict
+
+def collect_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--segments', type=str, nargs='+', help='Metadata TSVs for all segments')
+    parser.add_argument('--metadata', type=str, help='Metadata TSV which will be amended for output. Must also appear in --segments.')
+    parser.add_argument('--output',   type=str, help='metadata file name')
+    return parser.parse_args()
+
+def read_metadata(fname, strains_only=False):
+    strains = set()
+    rows = []
+    with open(fname) as csvfile:
+        reader = csv.DictReader(csvfile, delimiter='\t')
+        for row in reader:
+            strains.add(row['strain'])
+            if not strains_only:
+                rows.append(row)
+    if strains_only:
+        return strains
+    return (strains, reader.fieldnames, rows)
+
+def summary(strain_count):
+    ## Print some basic stats!
+    print("Num strains observed (across all segments): ", len(strain_count.keys()))
+    counts = [0]*9 # 1-indexed
+    for n in strain_count.values():
+        counts[n]+=1
+    for i in range(1,9):
+        print(f"Num strains observed in {i} segments: ", counts[i])
+
+
+if __name__=="__main__":
+    args = collect_args()
+    strain_count = defaultdict(int)
+    matching_metadata_file_provided = False
+
+    for fname in args.segments:
+        if fname==args.metadata:
+            matching_metadata_file_provided = True
+            _strains, fieldnames, rows = read_metadata(fname)
+        else:
+            _strains = read_metadata(fname, strains_only=True)
+        for s in _strains:
+            strain_count[s]+=1
+    if not matching_metadata_file_provided:
+        raise Exception("You must provide a --metadata file which exactly matches one of the provided --segments files")
+    
+    summary(strain_count)
+
+    # append count to data for output
+    column = "n_segments"
+    fieldnames.append(column)
+    for row in rows:
+        row[column]=strain_count[row['strain']]
+    
+    with open(args.output, 'w') as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames, delimiter='\t')
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+    print("Output written to", args.output)


### PR DESCRIPTION
**how to use (copied from README)**


By default we subsample data for each segment independently. Alternatively, you can ask the pipeline to use the same strains for each segment. This modifies the pipeline in a few ways:

1. An additional metadata processing step is added which counts the number of segments a strain has sequence data for
2. Subsampling is performed as normal for the HA segment, with the additional condition that each sample has sequence data for all segments
3. All other segments are subsampled to contain the same strains as used for HA in step 2

To enable this set the config parameter `same_strains_per_segment` to a truthy value. If you are calling `snakemake` directly you can add

    --config 'same_strains_per_segment=True'

If you are using `nextstrain build` then add that to the end of the command (i.e. as a parameter which will be passed through to Snakemake).


**modifications to Snakefile**

This required adding a few more lambda / conditional functions. Let me know if anything's confusing and I can add more comments etc.

**need to rebase**

I need to rebase this on master to include daf5151e02faa1e5c2292c19cfaba368bdcab3e7 but this shouldn't prevent comments on this PR

**test runs on AWS**

I had a few issues which (I think) are unrelated to this PR as they failed in IQ-TREE due to unexpected characters in pb1/pb2 for h5nx and h5n1 builds. I'll post this in slack. (These failures are represented by "Error!" in the tables below.) I tested via:

    nextstrain build --aws-batch --cpus 16 --memory 28gib \
        --no-download --detach-on-interrupt \
        --envdir ~/envdirs/rethink/ \
        . \
        --config 'same_strains_per_segment=True' --keep-going

You can see these all on nextstrain.org/staging via the following tanglegram URLs:



**subtype: h5nx**

| segment | na | ha | pa | np | mp | ns | pb1 | pb2 |
| ---     | --- | --- | --- | --- | --- | --- | --- | --- |
| na |  |  |  |  |  |  |  |  |  |
| ha | [ha:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5nx/ha:staging/avian-flu/same-strains-per-segment/h5nx/na) |  |  |  |  |  |  |  |  |
| pa | [pa:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5nx/pa:staging/avian-flu/same-strains-per-segment/h5nx/na) | [pa:ha](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5nx/pa:staging/avian-flu/same-strains-per-segment/h5nx/ha) |  |  |  |  |  |  |  |
| np | [np:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5nx/np:staging/avian-flu/same-strains-per-segment/h5nx/na) | [np:ha](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5nx/np:staging/avian-flu/same-strains-per-segment/h5nx/ha) | [np:pa](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5nx/np:staging/avian-flu/same-strains-per-segment/h5nx/pa) |  |  |  |  |  |  |
| mp | [mp:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5nx/mp:staging/avian-flu/same-strains-per-segment/h5nx/na) | [mp:ha](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5nx/mp:staging/avian-flu/same-strains-per-segment/h5nx/ha) | [mp:pa](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5nx/mp:staging/avian-flu/same-strains-per-segment/h5nx/pa) | [mp:np](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5nx/mp:staging/avian-flu/same-strains-per-segment/h5nx/np) |  |  |  |  |  |
| ns | [ns:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5nx/ns:staging/avian-flu/same-strains-per-segment/h5nx/na) | [ns:ha](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5nx/ns:staging/avian-flu/same-strains-per-segment/h5nx/ha) | [ns:pa](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5nx/ns:staging/avian-flu/same-strains-per-segment/h5nx/pa) | [ns:np](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5nx/ns:staging/avian-flu/same-strains-per-segment/h5nx/np) | [ns:mp](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5nx/ns:staging/avian-flu/same-strains-per-segment/h5nx/mp) |  |  |  |  |
| pb1 | Error! | Error! | Error! | Error! | Error! | Error! |  |  |  |
| pb2 | Error! | Error! | Error! | Error! | Error! | Error! | Error! |  |  |


**subtype: h5n1**

| segment | na | ha | pa | np | mp | ns | pb1 | pb2 |
| ---     | --- | --- | --- | --- | --- | --- | --- | --- |
| na |  |  |  |  |  |  |  |  |  |
| ha | [ha:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5n1/ha:staging/avian-flu/same-strains-per-segment/h5n1/na) |  |  |  |  |  |  |  |  |
| pa | [pa:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5n1/pa:staging/avian-flu/same-strains-per-segment/h5n1/na) | [pa:ha](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5n1/pa:staging/avian-flu/same-strains-per-segment/h5n1/ha) |  |  |  |  |  |  |  |
| np | [np:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5n1/np:staging/avian-flu/same-strains-per-segment/h5n1/na) | [np:ha](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5n1/np:staging/avian-flu/same-strains-per-segment/h5n1/ha) | [np:pa](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5n1/np:staging/avian-flu/same-strains-per-segment/h5n1/pa) |  |  |  |  |  |  |
| mp | [mp:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5n1/mp:staging/avian-flu/same-strains-per-segment/h5n1/na) | [mp:ha](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5n1/mp:staging/avian-flu/same-strains-per-segment/h5n1/ha) | [mp:pa](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5n1/mp:staging/avian-flu/same-strains-per-segment/h5n1/pa) | [mp:np](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5n1/mp:staging/avian-flu/same-strains-per-segment/h5n1/np) |  |  |  |  |  |
| ns | [ns:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5n1/ns:staging/avian-flu/same-strains-per-segment/h5n1/na) | [ns:ha](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5n1/ns:staging/avian-flu/same-strains-per-segment/h5n1/ha) | [ns:pa](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5n1/ns:staging/avian-flu/same-strains-per-segment/h5n1/pa) | [ns:np](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5n1/ns:staging/avian-flu/same-strains-per-segment/h5n1/np) | [ns:mp](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h5n1/ns:staging/avian-flu/same-strains-per-segment/h5n1/mp) |  |  |  |  |
| pb1 | Error! | Error! | Error! | Error! | Error! | Error! |  |  |  |
| pb2 | Error! | Error! | Error! | Error! | Error! | Error! | Error! |  |  |


**subtype: h9n2**

| segment | na | ha | pa | np | mp | ns | pb1 | pb2 |
| ---     | --- | --- | --- | --- | --- | --- | --- | --- |
| na |  |  |  |  |  |  |  |  |  |
| ha | [ha:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/ha:staging/avian-flu/same-strains-per-segment/h9n2/na) |  |  |  |  |  |  |  |  |
| pa | [pa:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/pa:staging/avian-flu/same-strains-per-segment/h9n2/na) | [pa:ha](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/pa:staging/avian-flu/same-strains-per-segment/h9n2/ha) |  |  |  |  |  |  |  |
| np | [np:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/np:staging/avian-flu/same-strains-per-segment/h9n2/na) | [np:ha](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/np:staging/avian-flu/same-strains-per-segment/h9n2/ha) | [np:pa](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/np:staging/avian-flu/same-strains-per-segment/h9n2/pa) |  |  |  |  |  |  |
| mp | [mp:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/mp:staging/avian-flu/same-strains-per-segment/h9n2/na) | [mp:ha](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/mp:staging/avian-flu/same-strains-per-segment/h9n2/ha) | [mp:pa](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/mp:staging/avian-flu/same-strains-per-segment/h9n2/pa) | [mp:np](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/mp:staging/avian-flu/same-strains-per-segment/h9n2/np) |  |  |  |  |  |
| ns | [ns:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/ns:staging/avian-flu/same-strains-per-segment/h9n2/na) | [ns:ha](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/ns:staging/avian-flu/same-strains-per-segment/h9n2/ha) | [ns:pa](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/ns:staging/avian-flu/same-strains-per-segment/h9n2/pa) | [ns:np](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/ns:staging/avian-flu/same-strains-per-segment/h9n2/np) | [ns:mp](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/ns:staging/avian-flu/same-strains-per-segment/h9n2/mp) |  |  |  |  |
| pb1 | [pb1:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/pb1:staging/avian-flu/same-strains-per-segment/h9n2/na) | [pb1:ha](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/pb1:staging/avian-flu/same-strains-per-segment/h9n2/ha) | [pb1:pa](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/pb1:staging/avian-flu/same-strains-per-segment/h9n2/pa) | [pb1:np](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/pb1:staging/avian-flu/same-strains-per-segment/h9n2/np) | [pb1:mp](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/pb1:staging/avian-flu/same-strains-per-segment/h9n2/mp) | [pb1:ns](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/pb1:staging/avian-flu/same-strains-per-segment/h9n2/ns) |  |  |  |
| pb2 | [pb2:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/pb2:staging/avian-flu/same-strains-per-segment/h9n2/na) | [pb2:ha](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/pb2:staging/avian-flu/same-strains-per-segment/h9n2/ha) | [pb2:pa](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/pb2:staging/avian-flu/same-strains-per-segment/h9n2/pa) | [pb2:np](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/pb2:staging/avian-flu/same-strains-per-segment/h9n2/np) | [pb2:mp](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/pb2:staging/avian-flu/same-strains-per-segment/h9n2/mp) | [pb2:ns](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/pb2:staging/avian-flu/same-strains-per-segment/h9n2/ns) | [pb2:pb1](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h9n2/pb2:staging/avian-flu/same-strains-per-segment/h9n2/pb1) |  |  |


**subtype: h7n9**

| segment | na | ha | pa | np | mp | ns | pb1 | pb2 |
| ---     | --- | --- | --- | --- | --- | --- | --- | --- |
| na |  |  |  |  |  |  |  |  |  |
| ha | [ha:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/ha:staging/avian-flu/same-strains-per-segment/h7n9/na) |  |  |  |  |  |  |  |  |
| pa | [pa:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/pa:staging/avian-flu/same-strains-per-segment/h7n9/na) | [pa:ha](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/pa:staging/avian-flu/same-strains-per-segment/h7n9/ha) |  |  |  |  |  |  |  |
| np | [np:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/np:staging/avian-flu/same-strains-per-segment/h7n9/na) | [np:ha](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/np:staging/avian-flu/same-strains-per-segment/h7n9/ha) | [np:pa](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/np:staging/avian-flu/same-strains-per-segment/h7n9/pa) |  |  |  |  |  |  |
| mp | [mp:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/mp:staging/avian-flu/same-strains-per-segment/h7n9/na) | [mp:ha](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/mp:staging/avian-flu/same-strains-per-segment/h7n9/ha) | [mp:pa](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/mp:staging/avian-flu/same-strains-per-segment/h7n9/pa) | [mp:np](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/mp:staging/avian-flu/same-strains-per-segment/h7n9/np) |  |  |  |  |  |
| ns | [ns:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/ns:staging/avian-flu/same-strains-per-segment/h7n9/na) | [ns:ha](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/ns:staging/avian-flu/same-strains-per-segment/h7n9/ha) | [ns:pa](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/ns:staging/avian-flu/same-strains-per-segment/h7n9/pa) | [ns:np](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/ns:staging/avian-flu/same-strains-per-segment/h7n9/np) | [ns:mp](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/ns:staging/avian-flu/same-strains-per-segment/h7n9/mp) |  |  |  |  |
| pb1 | [pb1:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/pb1:staging/avian-flu/same-strains-per-segment/h7n9/na) | [pb1:ha](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/pb1:staging/avian-flu/same-strains-per-segment/h7n9/ha) | [pb1:pa](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/pb1:staging/avian-flu/same-strains-per-segment/h7n9/pa) | [pb1:np](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/pb1:staging/avian-flu/same-strains-per-segment/h7n9/np) | [pb1:mp](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/pb1:staging/avian-flu/same-strains-per-segment/h7n9/mp) | [pb1:ns](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/pb1:staging/avian-flu/same-strains-per-segment/h7n9/ns) |  |  |  |
| pb2 | [pb2:na](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/pb2:staging/avian-flu/same-strains-per-segment/h7n9/na) | [pb2:ha](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/pb2:staging/avian-flu/same-strains-per-segment/h7n9/ha) | [pb2:pa](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/pb2:staging/avian-flu/same-strains-per-segment/h7n9/pa) | [pb2:np](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/pb2:staging/avian-flu/same-strains-per-segment/h7n9/np) | [pb2:mp](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/pb2:staging/avian-flu/same-strains-per-segment/h7n9/mp) | [pb2:ns](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/pb2:staging/avian-flu/same-strains-per-segment/h7n9/ns) | [pb2:pb1](https://nextstrain.org/staging/avian-flu/same-strains-per-segment/h7n9/pb2:staging/avian-flu/same-strains-per-segment/h7n9/pb1) |  |  |

