### PR TITLE
Update Auspice config files

### DIFF
--- a/config/auspice_config_h5n1.json
+++ b/config/auspice_config_h5n1.json
@@ -21,13 +21,13 @@
       "type": "continuous"
     },
     {
-      "key": "country",
-      "title": "Country",
+      "key": "region",
+      "title": "Region",
       "type": "categorical"
     },
     {
-      "key": "region",
-      "title": "Region",
+      "key": "country",
+      "title": "Country",
       "type": "categorical"
     },
     {
@@ -47,22 +47,22 @@
     },
     {
       "key": "h5_label_clade",
-      "title": "Provisional LABEL clade",
+      "title": "Provisional LABEL Clade",
       "type": "categorical"
     },
     {
       "key": "gisaid_clade",
-      "title": "GISAID clade",
+      "title": "GISAID Clade",
       "type": "categorical"
     },
     {
       "key": "furin_cleavage_motif",
-      "title": "furin cleavage motif",
+      "title": "Furin Cleavage Motif",
       "type": "categorical"
     },
     {
       "key": "cleavage_site_sequence",
-      "title": "cleavage site sequence",
+      "title": "Cleavage Site Sequence",
       "type": "categorical"
     },
     {
@@ -71,24 +71,20 @@
       "type": "categorical"
     },
     {
-      "key": "PMID",
-      "title": "Pubmed ID",
+      "key": "originating_lab",
+      "title": "Originating Lab",
       "type": "categorical"
     },
     {
       "key": "submitting_lab",
-      "title": "Submitting lab",
-      "type": "categorical"
-    },
-    {
-      "key": "originating_lab",
-      "title": "Originating lab",
+      "title": "Submitting Lab",
       "type": "categorical"
     }
   ],
   "geo_resolutions": [
     "region",
-    "country"
+    "country",
+    "division"
   ],
   "display_defaults": {
     "map_triplicate": true,
@@ -99,10 +95,12 @@
     "domestic_status",
     "region",
     "country",
-    "submitting_lab",
+    "division",
     "subtype",
     "h5_label_clade",
     "gisaid_clade",
-    "authors"
+    "authors",
+    "originating_lab",
+    "submitting_lab"
   ]
 }

--- a/config/auspice_config_h5nx.json
+++ b/config/auspice_config_h5nx.json
@@ -21,13 +21,13 @@
       "type": "continuous"
     },
     {
-      "key": "country",
-      "title": "Country",
+      "key": "region",
+      "title": "Region",
       "type": "categorical"
     },
     {
-      "key": "region",
-      "title": "Region",
+      "key": "country",
+      "title": "Country",
       "type": "categorical"
     },
     {
@@ -47,22 +47,22 @@
     },
     {
       "key": "h5_label_clade",
-      "title": "Provisional LABEL clade",
+      "title": "Provisional LABEL Clade",
       "type": "categorical"
     },
     {
       "key": "gisaid_clade",
-      "title": "GISAID clade",
+      "title": "GISAID Clade",
       "type": "categorical"
     },
     {
       "key": "furin_cleavage_motif",
-      "title": "furin cleavage motif",
+      "title": "Furin Cleavage Motif",
       "type": "categorical"
     },
     {
       "key": "cleavage_site_sequence",
-      "title": "cleavage site sequence",
+      "title": "Cleavage Site Sequence",
       "type": "categorical"
     },
     {
@@ -71,24 +71,20 @@
       "type": "categorical"
     },
     {
-      "key": "PMID",
-      "title": "Pubmed ID",
+      "key": "originating_lab",
+      "title": "Originating Lab",
       "type": "categorical"
     },
     {
       "key": "submitting_lab",
-      "title": "Submitting lab",
-      "type": "categorical"
-    },
-    {
-      "key": "originating_lab",
-      "title": "Originating lab",
+      "title": "Submitting Lab",
       "type": "categorical"
     }
   ],
   "geo_resolutions": [
     "region",
-    "country"
+    "country",
+    "division"
   ],
   "display_defaults": {
     "map_triplicate": true,
@@ -99,10 +95,12 @@
     "domestic_status",
     "region",
     "country",
-    "submitting_lab",
+    "division",
     "subtype",
     "h5_label_clade",
     "gisaid_clade",
-    "authors"
+    "authors",
+    "originating_lab",
+    "submitting_lab"
   ]
 }

--- a/config/auspice_config_h7n9.json
+++ b/config/auspice_config_h7n9.json
@@ -8,7 +8,7 @@
     {
       "name": "GISAID"
     }
-  ],  
+  ],
   "colorings": [
     {
       "key": "gt",
@@ -27,7 +27,7 @@
     },
     {
       "key": "division",
-      "title": "Division",
+      "title": "Admin Division",
       "type": "categorical"
     },
     {
@@ -37,22 +37,22 @@
     },
     {
       "key": "furin_cleavage_motif",
-      "title": "furin cleavage motif",
+      "title": "Furin Cleavage Motif",
       "type": "categorical"
     },
     {
       "key": "cleavage_site_sequence",
-      "title": "cleavage site sequence",
-      "type": "categorical"
-    },
-    {
-      "key": "submitting_lab",
-      "title": "Submitting lab",
+      "title": "Cleavage Site Sequence",
       "type": "categorical"
     },
     {
       "key": "originating_lab",
-      "title": "Originating lab",
+      "title": "Originating Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting Lab",
       "type": "categorical"
     }
   ],
@@ -69,6 +69,7 @@
     "host",
     "country",
     "division",
+    "originating_lab",
     "submitting_lab"
   ]
 }

--- a/config/auspice_config_h9n2.json
+++ b/config/auspice_config_h9n2.json
@@ -37,22 +37,22 @@
     },
     {
       "key": "furin_cleavage_motif",
-      "title": "furin cleavage motif",
+      "title": "Furin Cleavage Motif",
       "type": "categorical"
     },
     {
       "key": "cleavage_site_sequence",
-      "title": "cleavage site sequence",
-      "type": "categorical"
-    },
-    {
-      "key": "submitting_lab",
-      "title": "Submitting lab",
+      "title": "Cleavage Site Sequence",
       "type": "categorical"
     },
     {
       "key": "originating_lab",
-      "title": "Originating lab",
+      "title": "Originating Lab",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting Lab",
       "type": "categorical"
     }
   ],
@@ -68,6 +68,7 @@
     "host",
     "region",
     "country",
+    "originating_lab",
     "submitting_lab"
   ]
 }


### PR DESCRIPTION
This PR was motivated initially by wanting to include "division" as a geo resolution, but then expanded to:

1. Make coloring appropriately capitalized (consistent with ncov)
2. Call it "Admin Division" for clarity
3. Include "Originating Lab" as filter and make sure to always order as originating lab, then submitting lab.
4. Order as Region, Country, Division (consistent with ncov)
5. Drop PMID from colorings. This wasn't in the metadata and wasn't exported as coloring.