### PR TITLE
Specify CI target in a Snakemake rule

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,4 +8,4 @@ jobs:
   ci:
     uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master
     with:
-      build-args: auspice/avian-flu_h5n1_ha_all-time.json
+      build-args: test_target

--- a/Snakefile
+++ b/Snakefile
@@ -15,6 +15,12 @@ rule all:
     input:
         auspice_json = all_targets()
 
+rule test_target:
+    """
+    For testing purposes such as CI workflows.
+    """
+    input: "auspice/avian-flu_h5n1_ha_all-time.json"
+
 rule files:
     params:
         dropped_strains = "config/dropped_strains_{subtype}.txt",


### PR DESCRIPTION
## Description of proposed changes

Previously, updates to build names prompted tedious changes in downstream CI usage, such as:

- https://github.com/nextstrain/augur/commit/ef79e167fff260320dba4879ed51b2164768dc5d
- https://github.com/nextstrain/docker-base/commit/ebe2e5551e2fdaf057fac4238445e34f575606cf
- https://github.com/nextstrain/conda-base/commit/2cda9b003af66c7eb9f606606801a5701b8cb394

Now, such changes only require updates within this pathogen repo.

## Related issue(s)

- suggested in https://github.com/nextstrain/avian-flu/pull/12#discussion_r1572815813
- prompted by #14 breaking downstream CI usage

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Make PRs on downstream repos to use this new target
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
