### PR TITLE
Inline root sequence

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -430,7 +430,7 @@ rule export:
             --lat-longs {input.lat_longs} \
             --auspice-config {input.auspice_config} \
             --description {input.description} \
-            --include-root-sequence \
+            --include-root-sequence-inline \
             --output {output.auspice_json}
         """
 


### PR DESCRIPTION
The sequence size is small relative to the typical dataset size and for a full run reduces the number of output auspice files from 96 to 48.

@lmoncla I'm not sure if you have downstream scripts which rely on `*_root-sequence.json`?