### PR TITLE
Add download logic to "full genome" workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,13 @@ Specifically, the files needed are `ingest/results/metadata.tsv` and `ingest/res
 
 #### Running full genome builds
 
-Run `snakemake` / `nextstrain build` with `--snakefile Snakefile.genome`
+Run full genome builds with the following command.
 
-Currently this is only set up for the "h5n1-cattle-outbreak" build, and restricts the build to a set of strains where we think there's no reassortment (`config/include_strains_h5n1-cattle-outbreak.txt`). Output files will be placed in `results/h5n1-cattle-outbreak/genome`. Input files must be created by running (part of) the main workflow to produce `data/sequences_h5n1_{segment}.fasta` and `data/metadata_h5n1.tsv` files. See `Snakefile.genome` for more details.
+``` bash
+nextstrain build . --snakefile Snakefile.genome
+```
+
+Currently this is only set up for the "h5n1-cattle-outbreak" build, and restricts the build to a set of strains where we think there's no reassortment (`config/include_strains_h5n1-cattle-outbreak.txt`). Output files will be placed in `results/h5n1-cattle-outbreak/genome`. See `Snakefile.genome` for more details.
 
 
 ### To modify this build to work with your own data

--- a/Snakefile
+++ b/Snakefile
@@ -1,9 +1,9 @@
+include: "rules/common.smk"
+
 SUBTYPES = config.get('subtypes', ["h5nx", "h5n1", "h7n9", "h9n2"])
 SEGMENTS = config.get('segments', ["pb2", "pb1", "pa", "ha","np", "na", "mp", "ns"])
 TIME =     config.get('time',     ["all-time","2y"])
 TARGET_SEQUENCES_PER_TREE = config.get('n_seqs', 3000)
-S3_SRC = config.get('s3_src', "s3://nextstrain-data-private/files/workflows/avian-flu")
-LOCAL_INGEST = bool(config.get('local_ingest', False))
 
 # The config option `same_strains_per_segment=True'` (e.g. supplied to snakemake via --config command line argument)
 # will change the behaviour of the workflow to use the same strains for each segment. This is achieved via these steps:
@@ -40,15 +40,6 @@ rule files:
         description = "config/description.md"
 
 files = rules.files.params
-
-def subtypes_by_subtype_wildcard(wildcards):
-    db = {
-        'h5nx': ['h5n1', 'h5n2', 'h5n3', 'h5n4', 'h5n5', 'h5n6', 'h5n7', 'h5n8', 'h5n9'],
-        'h5n1': ['h5n1'],
-        'h7n9': ['h7n9'],
-        'h9n2': ['h9n2'],
-    }
-    return(db[wildcards.subtype])
 
 def metadata_by_wildcards(wildcards):
     if wildcards.subtype in ("h5n1", "h5nx"):
@@ -125,78 +116,6 @@ def clock_rate_std_dev(w):
         }
 
     return clock_rate_std_dev[w.subtype][w.time]
-
-if LOCAL_INGEST:
-    rule copy_sequences_from_ingest:
-        output:
-            sequences = "data/{segment}/sequences.fasta",
-        params:
-            sequences = lambda w: f"ingest/results/sequences_{w.segment}.fasta"
-        shell:
-            """
-            cp {params.sequences} {output.sequences}
-            """
-
-    rule copy_metadata_from_ingest:
-        output:
-            metadata = "data/metadata.tsv",
-        shell:
-            """
-            cp ingest/results/metadata.tsv {output.metadata}
-            """
-
-else:
-    rule download_sequences:
-        output:
-            sequences = "data/{segment}/sequences.fasta",
-        params:
-            s3_src=S3_SRC,
-        shell:
-            """
-            aws s3 cp {params.s3_src:q}/{wildcards.segment}/sequences.fasta.zst - | zstd -d > {output.sequences}
-            """
-
-    rule download_metadata:
-        output:
-            metadata = "data/metadata.tsv",
-        params:
-            s3_src=S3_SRC,
-        shell:
-            """
-            aws s3 cp {params.s3_src:q}/metadata.tsv.zst - | zstd -d > {output.metadata}
-            """
-
-rule filter_sequences_by_subtype:
-    input:
-        sequences = "data/{segment}/sequences.fasta",
-        metadata = "data/metadata.tsv",
-    output:
-        sequences = "data/sequences_{subtype}_{segment}.fasta",
-    params:
-        subtypes=subtypes_by_subtype_wildcard,
-    shell:
-        """
-        augur filter \
-            --sequences {input.sequences} \
-            --metadata {input.metadata} \
-            --query "subtype in {params.subtypes!r}" \
-            --output-sequences {output.sequences}
-        """
-
-rule filter_metadata_by_subtype:
-    input:
-        metadata = "data/metadata.tsv",
-    output:
-        metadata = "data/metadata_{subtype}.tsv",
-    params:
-        subtypes=subtypes_by_subtype_wildcard,
-    shell:
-        """
-        augur filter \
-            --metadata {input.metadata} \
-            --query "subtype in {params.subtypes!r}" \
-            --output-metadata {output.metadata}
-        """
 
 rule add_h5_clade:
     message: "Adding in a column for h5 clade numbering"

--- a/Snakefile.genome
+++ b/Snakefile.genome
@@ -1,3 +1,5 @@
+include: "rules/common.smk"
+
 import json
 
 # -------------------- notes --------------------

--- a/config/dropped_strains_h9n2.txt
+++ b/config/dropped_strains_h9n2.txt
@@ -5,3 +5,4 @@ A/Chicken/Egypt/AR541/2018  # very divergent
 A/Chicken/Egypt/AR562/2018 # very divergent
 A/chicken/Hunan/1217YYGK0025P/2014_Mixed
 A/environment/Wuxi/2505/2014
+A/swine/Yantai/16/2012

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -1,0 +1,83 @@
+S3_SRC = config.get('s3_src', "s3://nextstrain-data-private/files/workflows/avian-flu")
+LOCAL_INGEST = bool(config.get('local_ingest', False))
+
+def subtypes_by_subtype_wildcard(wildcards):
+    db = {
+        'h5nx': ['h5n1', 'h5n2', 'h5n3', 'h5n4', 'h5n5', 'h5n6', 'h5n7', 'h5n8', 'h5n9'],
+        'h5n1': ['h5n1'],
+        'h7n9': ['h7n9'],
+        'h9n2': ['h9n2'],
+    }
+    return(db[wildcards.subtype])
+
+if LOCAL_INGEST:
+    rule copy_sequences_from_ingest:
+        output:
+            sequences = "data/{segment}/sequences.fasta",
+        params:
+            sequences = lambda w: f"ingest/results/sequences_{w.segment}.fasta"
+        shell:
+            """
+            cp {params.sequences} {output.sequences}
+            """
+
+    rule copy_metadata_from_ingest:
+        output:
+            metadata = "data/metadata.tsv",
+        shell:
+            """
+            cp ingest/results/metadata.tsv {output.metadata}
+            """
+
+else:
+    rule download_sequences:
+        output:
+            sequences = "data/{segment}/sequences.fasta",
+        params:
+            s3_src=S3_SRC,
+        shell:
+            """
+            aws s3 cp {params.s3_src:q}/{wildcards.segment}/sequences.fasta.zst - | zstd -d > {output.sequences}
+            """
+
+    rule download_metadata:
+        output:
+            metadata = "data/metadata.tsv",
+        params:
+            s3_src=S3_SRC,
+        shell:
+            """
+            aws s3 cp {params.s3_src:q}/metadata.tsv.zst - | zstd -d > {output.metadata}
+            """
+
+rule filter_sequences_by_subtype:
+    input:
+        sequences = "data/{segment}/sequences.fasta",
+        metadata = "data/metadata.tsv",
+    output:
+        sequences = "data/sequences_{subtype}_{segment}.fasta",
+    params:
+        subtypes=subtypes_by_subtype_wildcard,
+    shell:
+        """
+        augur filter \
+            --sequences {input.sequences} \
+            --metadata {input.metadata} \
+            --query "subtype in {params.subtypes!r}" \
+            --output-sequences {output.sequences}
+        """
+
+rule filter_metadata_by_subtype:
+    input:
+        metadata = "data/metadata.tsv",
+    output:
+        metadata = "data/metadata_{subtype}.tsv",
+    params:
+        subtypes=subtypes_by_subtype_wildcard,
+    shell:
+        """
+        augur filter \
+            --metadata {input.metadata} \
+            --query "subtype in {params.subtypes!r}" \
+            --output-metadata {output.metadata}
+        """


### PR DESCRIPTION
## Description of proposed changes

Refactors download/copy logic and configuration variables from the main workflow's Snakefile into a common rules file and includes this common file in both the main workflow and the "full genome" workflow. This change allows the full genome workflow to download/copy the files it needs from scratch without requiring the user to first download those file from the main workflow.

This implementation is not ideal in that the definition and appearance of configuration variables like the S3 bucket get moved into an even less obvious place than the top-level Snakefile. Ideally, we would define these variables in a standard configuration YAML file. This commit does not introduce a YAML config file yet, in favor of making a single small improvement to the workflow.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Tested full genome build locally from an empty `data/` directory
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
