### PR TITLE
Snakefile: Conditionally include `--no-sign-request` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ These use NCBI data including consensus genomes and SRA data assembled via the A
 snakemake --cores 1 -pf --configfile config/h5n1-cattle-outbreak.yaml
 ```
 
-This pipeline starts by downloading data from a public S3 bucket, however credentials may still be required to interact with AWS S3 buckets.
+This pipeline starts by downloading data from a public S3 bucket.
 
 
 **Genome builds**

--- a/Snakefile
+++ b/Snakefile
@@ -197,7 +197,7 @@ def refine_clock_rates(w):
 
     assert isinstance(info[w.segment], list), "The clock rates for {w.subtype!r} {w.time!r} {w.segment!r} must be a list of (rate, std-dev)"
     assert len(info[w.segment])==2, "The clock rates for {w.subtype!r} {w.time!r} {w.segment!r} must be a list of (rate, std-dev)"
-    return f"--clock-rate {info[w.segment][0]} --clock-std-dev {info[w.segment][1]}"   
+    return f"--clock-rate {info[w.segment][0]} --clock-std-dev {info[w.segment][1]}"
 
 def refine_clock_filter(w):
     filter = get_config('refine', 'clock_filter_iqd', w)
@@ -297,7 +297,7 @@ rule align:
     output:
         alignment = "results/{subtype}/{segment}/{time}/aligned.fasta"
     wildcard_constraints:
-        # for genome builds we don't use this rule; see `rule join_segments` 
+        # for genome builds we don't use this rule; see `rule join_segments`
         segment = "|".join(seg for seg in SEGMENTS)
     threads:
         4


### PR DESCRIPTION
## Description of proposed changes

Conditionally include `--no-sign-request` option for download rules if the `s3_src` config param is pointing to the public Nextstrain S3 bucket (s3://nextstrain-data/).

This means AWS credentials are no longer necessary for the public h5n1-cattle-outbreak genome build.

After running `nextstrain update docker`, I can successfully run the h5n1-cattle-outbreak build with:

```
nextstrain build . \
    --snakefile Snakefile.genome \
    --config s3_src=s3://nextstrain-data/files/workflows/avian-flu/h5n1
```

Or you can point to the specific image 
```
nextstrain build --image nextstrain/base:build-20240612T230750Z . \
    --snakefile Snakefile.genome \
    --config s3_src=s3://nextstrain-data/files/workflows/avian-flu/h5n1
```

## Related issue(s)

Dependent on https://github.com/nextstrain/docker-base/pull/215
Follow up to #47

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
