### PR TITLE
ingest: Add new host from NCBI data

### DIFF
--- a/ingest/build-configs/ncbi/defaults/host-map.tsv
+++ b/ingest/build-configs/ncbi/defaults/host-map.tsv
@@ -33,6 +33,7 @@ Lophodytes cucullatus	Avian
 Meleagris gallopavo	Avian
 Mephitidae	Nonhuman Mammal
 mountain_lion	Nonhuman Mammal
+Panthera leo	Nonhuman Mammal
 Pelecanus erythrorhynchos	Avian
 Procyon lotor	Nonhuman Mammal
 Turdus merula	Avian


### PR DESCRIPTION
"Panthera leo" == lions but this host value came in for these records:
A/mountain_lion/Montana/24-005908-001/2024
A/mountain_lion/Montana/24-010315-001/2024

Both get mapped to "Nonhuman Mammal" so it doesn't really matter here,
just wanted to note the oddity.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
