### PR TITLE
Add GH Action workflows for ingest

### DIFF
--- a/.github/workflows/ingest-fauna.yaml
+++ b/.github/workflows/ingest-fauna.yaml
@@ -1,0 +1,42 @@
+name: Ingest fauna
+
+defaults:
+  run:
+    # This is the same as GitHub Action's `bash` keyword as of 20 June 2023:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    #
+    # Completely spelling it out here so that GitHub can't change it out from under us
+    # and we don't have to refer to the docs to know the expected behavior.
+    shell: bash --noprofile --norc -eo pipefail {0}
+
+on:
+  workflow_dispatch:
+
+jobs:
+  ingest:
+    permissions:
+      id-token: write
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    secrets: inherit
+    with:
+      # Starting with the default docker runtime
+      # We can migrate to AWS Batch when/if we need to for more resources or if
+      # the job runs longer than the GH Action limit of 6 hours.
+      runtime: docker
+      run: |
+        nextstrain build \
+          --env RETHINK_HOST \
+          --env RETHINK_AUTH_KEY \
+          ingest \
+            upload_all
+      # Specifying artifact name to differentiate ingest build outputs from
+      # the phylogenetic build outputs
+      artifact-name: ingest-fauna-build-output
+      # Explicitly excluding `ingest/fauna/results` and `ingest/fauna/data`
+      # since this is private data and should not available through the public artifacts
+      artifact-paths: |
+        !ingest/fauna/results/
+        !ingest/fauna/data/
+        ingest/.snakemake/log/
+        ingest/fauna/benchmarks/
+        ingest/fauna/logs/

--- a/.github/workflows/ingest-ncbi.yaml
+++ b/.github/workflows/ingest-ncbi.yaml
@@ -1,0 +1,65 @@
+name: Ingest NCBI
+
+defaults:
+  run:
+    # This is the same as GitHub Action's `bash` keyword as of 20 June 2023:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    #
+    # Completely spelling it out here so that GitHub can't change it out from under us
+    # and we don't have to refer to the docs to know the expected behavior.
+    shell: bash --noprofile --norc -eo pipefail {0}
+
+on:
+  schedule:
+    # Note times are in UTC, which is 1 or 2 hours behind CET depending on daylight savings.
+    #
+    # Note the actual runs might be late.
+    # Numerous people were confused, about that, including me:
+    #  - https://github.community/t/scheduled-action-running-consistently-late/138025/11
+    #  - https://github.com/github/docs/issues/3059
+    #
+    # Note, '*' is a special character in YAML, so you have to quote this string.
+    #
+    # Docs:
+    #  - https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
+    #
+    # Tool that deciphers this particular format of crontab string:
+    #  - https://crontab.guru/
+    #
+    # Runs at 5pm UTC (1pm EDT/10am PDT) since curation by NCBI happens on the East Coast.
+    # We were running into invalid zip archive errors at 9am PDT, so hoping an hour
+    # delay will lower the error frequency
+    - cron: '0 17 * * *'
+
+  workflow_dispatch:
+
+jobs:
+  ingest:
+    permissions:
+      id-token: write
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    secrets: inherit
+    with:
+      # Starting with the default docker runtime
+      # We can migrate to AWS Batch when/if we need to for more resources or if
+      # the job runs longer than the GH Action limit of 6 hours.
+      runtime: docker
+      run: |
+        nextstrain build \
+          ingest \
+            upload_all_ncbi \
+            --configfile build-configs/ncbi/defaults/config.yaml
+      # Specifying artifact name to differentiate ingest build outputs from
+      # the phylogenetic build outputs
+      artifact-name: ingest-ncbi-build-output
+      artifact-paths: |
+        ingest/.snakemake/log/
+        ingest/andersen-lab/results/
+        ingest/andersen-lab/benchmarks/
+        ingest/andersen-lab/logs/
+        ingest/joined-ncbi/results/
+        ingest/joined-ncbi/benchmarks/
+        ingest/joined-ncbi/logs/
+        ingest/ncbi/results/
+        ingest/ncbi/benchmarks/
+        ingest/ncbi/logs/


### PR DESCRIPTION
## Description of proposed changes

1. The `ingest-ncbi` GH Action workflow is scheduled to run daily at 10AM PDT so that we get automated updates of the NCBI data. 

2. The `ingest-fauna` GH Action workflow is available to be run manually as needed whenever new data has been uploaded to fauna. 

Outside of this PR, I had to [add avian-flu to our supported pathogens](https://github.com/nextstrain/infra/pull/20) to use the short-lived AWS credentials in `pathogen-repo-build` and added organization secrets `RETHINK_AUTH_KEY` and `RETHINK_HOST` to this repo. 

## Related issue(s)

Resolves #43 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Test ingest-ncbi run](https://github.com/nextstrain/avian-flu/actions/runs/9423448307)
- [x] [Test ingest-fauna run](https://github.com/nextstrain/avian-flu/actions/runs/9423560154)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
