### PR TITLE
Switch Andersen lab metadata

### DIFF
--- a/ingest/build-configs/ncbi/bin/curate-andersen-lab-data
+++ b/ingest/build-configs/ncbi/bin/curate-andersen-lab-data
@@ -17,8 +17,8 @@ NEXTSTRAIN_RECORD = {
     'virus': 'avian_flu',
     'isolate_id': '?',
     'date': '?',
-    'region': 'North America',
-    'country': 'USA',
+    'region': '?',
+    'country': '?',
     'division': '?',
     'location': '?',
     'host': '?',
@@ -43,6 +43,8 @@ def create_new_record(anderson_record: dict) -> dict:
     new_record = copy.deepcopy(NEXTSTRAIN_RECORD)
     new_record['isolate_id'] = anderson_record['Run']
     new_record['sra_accessions'] = anderson_record['Run']
+    new_record['region'] = anderson_record['geo_loc_name_country_continent']
+    new_record['country'] = anderson_record['geo_loc_name_country']
 
     center_name = parse_center_name(anderson_record['Center Name'])
     new_record['originating_lab'] = center_name

--- a/ingest/build-configs/ncbi/bin/curate-andersen-lab-data
+++ b/ingest/build-configs/ncbi/bin/curate-andersen-lab-data
@@ -45,12 +45,12 @@ def create_new_record(anderson_record: dict) -> dict:
     new_record['sra_accessions'] = anderson_record['Run']
     new_record['region'] = anderson_record['geo_loc_name_country_continent']
     new_record['country'] = anderson_record['geo_loc_name_country']
+    new_record['host'] = anderson_record['Host']
 
     center_name = parse_center_name(anderson_record['Center Name'])
     new_record['originating_lab'] = center_name
     new_record['submitting_lab'] = center_name
 
-    new_record['host'] = parse_host_group(anderson_record['Host'])
     new_record['date'] = parse_date(anderson_record['Collection_Date'])
     new_record['strain'] = f'A/{anderson_record["Host"]}/{new_record["country"]}/{anderson_record["isolate"]}/{parse_year(new_record["date"])}'
     return new_record
@@ -61,37 +61,6 @@ def parse_center_name(center_name: str) -> str:
         return center_name.replace('-', ' ')
 
     return center_name
-
-
-def parse_host_group(host: str) -> str:
-    """
-    Bin `host` into the HOST_GROUPS
-    """
-    # Replace with enum.StrEnum starting with Python 3.11
-    class HOST_GROUPS(str, Enum):
-        AVIAN = 'Avian'
-        CATTLE = 'Cattle'
-        NONHUMAN_MAMMAL = 'Nonhuman Mammal'
-
-    known_hosts = {
-        'Blackbird': HOST_GROUPS.AVIAN,
-        'Cat': HOST_GROUPS.NONHUMAN_MAMMAL,
-        'Cattle': HOST_GROUPS.CATTLE,
-        'CAGO': HOST_GROUPS.AVIAN,
-        'Chicken': HOST_GROUPS.AVIAN,
-        'Grackle': HOST_GROUPS.AVIAN,
-        'Goose': HOST_GROUPS.AVIAN,
-        'PEFA': HOST_GROUPS.AVIAN,
-        'Skunk': HOST_GROUPS.NONHUMAN_MAMMAL,
-        'Raccoon': HOST_GROUPS.NONHUMAN_MAMMAL,
-    }
-
-    host_group = known_hosts.get(host)
-    if host_group is None:
-        print(f"WARNING: unable to group unknown host {host!r}", file=stderr)
-        return host
-
-    return host_group
 
 
 def parse_date(date_string: str) -> str:

--- a/ingest/build-configs/ncbi/bin/curate-andersen-lab-data
+++ b/ingest/build-configs/ncbi/bin/curate-andersen-lab-data
@@ -43,15 +43,13 @@ def create_new_record(anderson_record: dict) -> dict:
     new_record = copy.deepcopy(NEXTSTRAIN_RECORD)
     new_record['isolate_id'] = anderson_record['Run']
     new_record['sra_accessions'] = anderson_record['Run']
-    new_record['division'] = anderson_record['US State']
-    new_record['location'] = anderson_record['US State']
 
     center_name = parse_center_name(anderson_record['Center Name'])
     new_record['originating_lab'] = center_name
     new_record['submitting_lab'] = center_name
 
     new_record['host'] = parse_host_group(anderson_record['Host'])
-    new_record['date'] = parse_date(anderson_record['Date'])
+    new_record['date'] = parse_date(anderson_record['Collection_Date'])
     new_record['strain'] = f'A/{anderson_record["Host"]}/{new_record["country"]}/{anderson_record["isolate"]}/{parse_year(new_record["date"])}'
     return new_record
 
@@ -113,7 +111,7 @@ def parse_year(date_string: str) -> str:
     """
     Parse the year from the provided `date_string`
     """
-    date_formats = ['%Y-%m-%d', '%Y-XX-XX']
+    date_formats = ['%Y-%m-%d', '%Y', '%Y-XX-XX']
     for date_format in date_formats:
         try:
             parsed_date = datetime.strptime(date_string, date_format)

--- a/ingest/build-configs/ncbi/bin/curate-andersen-lab-data
+++ b/ingest/build-configs/ncbi/bin/curate-andersen-lab-data
@@ -46,12 +46,12 @@ def create_new_record(anderson_record: dict) -> dict:
     new_record['region'] = anderson_record['geo_loc_name_country_continent']
     new_record['country'] = anderson_record['geo_loc_name_country']
     new_record['host'] = anderson_record['Host']
+    new_record['date'] = anderson_record['Collection_Date']
 
     center_name = parse_center_name(anderson_record['Center Name'])
     new_record['originating_lab'] = center_name
     new_record['submitting_lab'] = center_name
 
-    new_record['date'] = parse_date(anderson_record['Collection_Date'])
     new_record['strain'] = f'A/{anderson_record["Host"]}/{new_record["country"]}/{anderson_record["isolate"]}/{parse_year(new_record["date"])}'
     return new_record
 
@@ -63,26 +63,11 @@ def parse_center_name(center_name: str) -> str:
     return center_name
 
 
-def parse_date(date_string: str) -> str:
-    """
-    If date_string is empty, 'NA', or includes a `?`, then returns the
-    hardcoded `2024-XX-XX` date.
-
-    Otherwise return the original date_string.
-    """
-    default_date = '2024-XX-XX'
-
-    if not date_string or date_string == 'NA' or '?' in date_string:
-        return default_date
-
-    return date_string
-
-
 def parse_year(date_string: str) -> str:
     """
     Parse the year from the provided `date_string`
     """
-    date_formats = ['%Y-%m-%d', '%Y', '%Y-XX-XX']
+    date_formats = ['%Y']
     for date_format in date_formats:
         try:
             parsed_date = datetime.strptime(date_string, date_format)

--- a/ingest/build-configs/ncbi/bin/curate-andersen-lab-data
+++ b/ingest/build-configs/ncbi/bin/curate-andersen-lab-data
@@ -45,15 +45,30 @@ def create_new_record(anderson_record: dict) -> dict:
     new_record['sra_accessions'] = anderson_record['Run']
     new_record['region'] = anderson_record['geo_loc_name_country_continent']
     new_record['country'] = anderson_record['geo_loc_name_country']
+    new_record['division'] = anderson_record.get('US State', '')
+    new_record['location'] = anderson_record.get('US State', '')
     new_record['host'] = anderson_record['Host']
-    new_record['date'] = anderson_record['Collection_Date']
 
+    new_record['date'] = use_date_when_available(anderson_record)
     center_name = parse_center_name(anderson_record['Center Name'])
     new_record['originating_lab'] = center_name
     new_record['submitting_lab'] = center_name
 
     new_record['strain'] = f'A/{anderson_record["Host"]}/{new_record["country"]}/{anderson_record["isolate"]}/{parse_year(new_record["date"])}'
     return new_record
+
+
+def use_date_when_available(andersen_record: dict) -> str:
+    """
+    Give the old date field `Date` precedence since they are more specific
+    """
+    old_date_field = andersen_record.get("Date", "")
+    old_date_uncertain = "NA" in old_date_field or "?" in old_date_field
+
+    if old_date_field and not old_date_uncertain:
+        return old_date_field
+
+    return andersen_record["Collection_Date"]
 
 
 def parse_center_name(center_name: str) -> str:
@@ -67,7 +82,7 @@ def parse_year(date_string: str) -> str:
     """
     Parse the year from the provided `date_string`
     """
-    date_formats = ['%Y']
+    date_formats = ['%Y-%m-%d', '%Y']
     for date_format in date_formats:
         try:
             parsed_date = datetime.strptime(date_string, date_format)

--- a/ingest/build-configs/ncbi/bin/transform-host
+++ b/ingest/build-configs/ncbi/bin/transform-host
@@ -11,7 +11,8 @@ from sys import stderr, stdin, stdout
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--host-map", required=True,
-        help="TSV file that maps `old_name` to the `new_name`.")
+        help="TSV file that maps `old_name` to the `new_name`. " +
+             "The `old_name` value is case-insensitive")
     return parser.parse_args()
 
 
@@ -19,12 +20,15 @@ def parse_host_map(host_map_file: str) -> dict:
     """
     Parse the provided *host_map_file* into a dictionary, where the key
     is the `old_name` and the values are the `new_name`.
+
+    The `old_name` is transformed to lowercase to support case-insensitive
+    comparisons.
     """
     host_map = {}
     with open(host_map_file) as tsv_file:
         reader = csv.DictReader(tsv_file, delimiter="\t")
         for row in reader:
-            host_map[row["old_name"]] = row["new_name"]
+            host_map[row["old_name"].lower()] = row["new_name"]
 
     return host_map
 
@@ -37,7 +41,8 @@ if __name__ == "__main__":
         record = json.loads(record).copy()
 
         host_field = record.get("host")
-        host = host_map.get(host_field)
+        # Do case-insensitive comparison of host_field to host_map
+        host = host_map.get(host_field.lower() if isinstance(host_field, str) else "")
         if host_field is None:
             print(
                 f"WARNING: Unable to transform host in record {index!r} " +

--- a/ingest/build-configs/ncbi/defaults/host-map.tsv
+++ b/ingest/build-configs/ncbi/defaults/host-map.tsv
@@ -1,39 +1,76 @@
 old_name	new_name
+alpaca	Nonhuman Mammal
+american crow	Avian
+american wigeon	Avian
 Anas platyrhynchos	Avian
 Anatidae	Avian
 Anser caerulescens	Avian
 Arenaria interpres	Avian
 Aythya americana	Avian
+bald eagle	Avian
+black billed magpie	Avian
+blackbird	Avian
 Bos taurus	Cattle
 Branta canadensis	Avian
 Bubo virginianus	Avian
 Buteo jamaicensis	Avian
+cago	Avian
 Calidris alba	Avian
+canada goose	Avian
 Capra hircus	Nonhuman Mammal
+cat	Nonhuman Mammal
 Cathartes aura	Avian
+cattle	Cattle
 Chenonetta jubata	Avian
+chicken	Avian
 Columbidae	Avian
+common raven	Avian
+comon-grackle	Avian
 Corvus	Avian
 Corvus brachyrhynchos	Avian
 Corvus corax	Avian
 Cygnus olor	Avian
 Dairy cattle	Cattle
+domestic cat	Nonhuman Mammal
+domestic-cat	Nonhuman Mammal
+duck	Avian
 environment	Environment
 Falco peregrinus	Avian
 Feliformia	Nonhuman Mammal
+feline	Nonhuman Mammal
 Felis catus	Nonhuman Mammal
 Gallus gallus	Avian
+ganada goose	Avian
+goat	Nonhuman Mammal
+goose	Avian
 grackle	Avian
+great horned owl	Avian
 Haliaeetus leucocephalus	Avian
+harris hawk	Avian
 harris-hawk	Avian
+hawk	Avian
 Homo sapiens	Human
 Icteridae	Avian
 Larus occidentalis	Avian
 Lophodytes cucullatus	Avian
+mallard	Avian
 Meleagris gallopavo	Avian
 Mephitidae	Nonhuman Mammal
+mountain lion	Nonhuman Mammal
 mountain_lion	Nonhuman Mammal
+mute swan	Avian
 Panthera leo	Nonhuman Mammal
+pefa	Avian
 Pelecanus erythrorhynchos	Avian
+pigeon	Avian
 Procyon lotor	Nonhuman Mammal
+raccoon	Nonhuman Mammal
+red fox	Nonhuman Mammal
+red tailed hawk	Avian
+skunk	Nonhuman Mammal
+snow goose	Avian
 Turdus merula	Avian
+turkey	Avian
+turkey vulture	Avian
+western gull	Avian
+western sandpiper	Avian

--- a/ingest/build-configs/ncbi/rules/ingest_andersen_lab.smk
+++ b/ingest/build-configs/ncbi/rules/ingest_andersen_lab.smk
@@ -22,14 +22,13 @@ rule extract_metadata:
     output:
         metadata = "andersen-lab/data/PRJNA1102327_metadata.csv"
     params:
-        output_dir = lambda wildcards, output: Path(output.metadata).parent
+        metadata_file_path = "metadata/SraRunTable_PRJNA1102327_automated.csv",
     shell:
         """
-        tar xz --file={input.andersen_lab_repo} \
-            --strip-components=2 \
-            -C {params.output_dir} \
+        tar xz -O --file={input.andersen_lab_repo} \
             --wildcards \
-            "*/metadata/PRJNA1102327_metadata.csv"
+            "*/{params.metadata_file_path:q}" \
+            > {output.metadata}
         """
 
 rule extract_consensus_sequences:

--- a/ingest/build-configs/ncbi/rules/ingest_andersen_lab.smk
+++ b/ingest/build-configs/ncbi/rules/ingest_andersen_lab.smk
@@ -78,11 +78,15 @@ rule curate_metadata:
         metadata = "andersen-lab/data/metadata.tsv"
     log:
         "andersen-lab/logs/curate_metadata.txt",
+    params:
+        host_map=config["curate"]["host_map"],
     shell:
         """
         augur curate normalize-strings \
             --metadata {input.metadata} \
             | ./build-configs/ncbi/bin/curate-andersen-lab-data \
+            | ./build-configs/ncbi/bin/transform-host \
+                --host-map {params.host_map} \
             | ./vendored/apply-geolocation-rules \
                 --geolocation-rules {input.geolocation_rules} \
             | augur curate passthru \

--- a/ingest/build-configs/ncbi/rules/ingest_andersen_lab.smk
+++ b/ingest/build-configs/ncbi/rules/ingest_andersen_lab.smk
@@ -80,11 +80,16 @@ rule curate_metadata:
         "andersen-lab/logs/curate_metadata.txt",
     params:
         host_map=config["curate"]["host_map"],
+        date_fields=['date'],
+        expected_date_formats=['%Y'],
     shell:
         """
         augur curate normalize-strings \
             --metadata {input.metadata} \
             | ./build-configs/ncbi/bin/curate-andersen-lab-data \
+            | augur curate format-dates \
+                --date-fields {params.date_fields} \
+                --expected-date-formats {params.expected_date_formats} \
             | ./build-configs/ncbi/bin/transform-host \
                 --host-map {params.host_map} \
             | ./vendored/apply-geolocation-rules \

--- a/ingest/build-configs/ncbi/rules/ingest_andersen_lab.smk
+++ b/ingest/build-configs/ncbi/rules/ingest_andersen_lab.smk
@@ -73,7 +73,8 @@ rule rename_and_concatenate_segment_fastas:
 rule curate_metadata:
     input:
         metadata = "andersen-lab/data/PRJNA1102327_metadata.csv",
-        geolocation_rules = "defaults/geolocation_rules.tsv"
+        geolocation_rules = "defaults/geolocation_rules.tsv",
+        annotations=config["curate"]["annotations"],
     output:
         metadata = "andersen-lab/data/metadata.tsv"
     log:
@@ -82,6 +83,7 @@ rule curate_metadata:
         host_map=config["curate"]["host_map"],
         date_fields=['date'],
         expected_date_formats=['%Y'],
+        annotations_id=config["curate"]["annotations_id"],
     shell:
         """
         augur curate normalize-strings \
@@ -94,6 +96,9 @@ rule curate_metadata:
                 --host-map {params.host_map} \
             | ./vendored/apply-geolocation-rules \
                 --geolocation-rules {input.geolocation_rules} \
+            | ./vendored/merge-user-metadata \
+                --annotations {input.annotations} \
+                --id-field {params.annotations_id} \
             | augur curate passthru \
                 --output-metadata {output.metadata} 2>> {log}
         """


### PR DESCRIPTION
## Description of proposed changes

Uses the latest automated metadata for the Andersen lab ingest workflow and includes small improvements for the Andersen lab ingest. 

I ran the workflow locally then compared the output metadata with the production metadata on S3. There were no differences in the previous records, but I do see an addition of 382 records from the Andersen lab ingest.

## Related issue(s)

Resolves #53 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
