### PR TITLE
h5n1-cattle-outbreak: Add Andersen lab to `data_provenance`

### DIFF
--- a/config/auspice_config_h5n1-cattle-outbreak.json
+++ b/config/auspice_config_h5n1-cattle-outbreak.json
@@ -11,6 +11,10 @@
       "url": "https://www.ncbi.nlm.nih.gov/bioproject/PRJNA1102327"
     },
     {
+      "name": "Andersen Lab",
+      "url": "https://github.com/andersen-lab/avian-influenza/"
+    },
+    {
       "name": "GenBank",
       "url": "https://www.ncbi.nlm.nih.gov/genbank/"
     }


### PR DESCRIPTION
Follow up on https://github.com/nextstrain/avian-flu/pull/50 which forgot to add the corresponding `data_provenance`

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
