### PR TITLE
ingest/joined-ncbi: Include `date_released` in metadata

### DIFF
--- a/ingest/build-configs/ncbi/bin/curate-andersen-lab-data
+++ b/ingest/build-configs/ncbi/bin/curate-andersen-lab-data
@@ -48,6 +48,7 @@ def create_new_record(anderson_record: dict) -> dict:
     new_record['division'] = anderson_record.get('US State', '')
     new_record['location'] = anderson_record.get('US State', '')
     new_record['host'] = anderson_record['Host']
+    new_record['date_released'] = anderson_record['ReleaseDate']
 
     new_record['date'] = use_date_when_available(anderson_record)
     center_name = parse_center_name(anderson_record['Center Name'])

--- a/ingest/build-configs/ncbi/defaults/config.yaml
+++ b/ingest/build-configs/ncbi/defaults/config.yaml
@@ -127,6 +127,7 @@ curate:
   - h5_clade
   - genbank_accession
   - sra_accessions
+  - date_released
 
 s3_dst:
   ncbi: s3://nextstrain-data/files/workflows/avian-flu/h5n1/ncbi

--- a/ingest/build-configs/ncbi/rules/ingest_andersen_lab.smk
+++ b/ingest/build-configs/ncbi/rules/ingest_andersen_lab.smk
@@ -123,8 +123,8 @@ rule curate_metadata:
         "andersen-lab/logs/curate_metadata.txt",
     params:
         host_map=config["curate"]["host_map"],
-        date_fields=['date'],
-        expected_date_formats=['%Y-%m-%d', '%Y'],
+        date_fields=['date', 'date_released'],
+        expected_date_formats=['%Y-%m-%d', '%Y', '%Y-%m-%d %H:%M:%S', '%Y-%m-%dT%H:%M:%SZ'],
         annotations_id=config["curate"]["annotations_id"],
     shell:
         """
@@ -132,8 +132,8 @@ rule curate_metadata:
             --metadata {input.metadata} \
             | ./build-configs/ncbi/bin/curate-andersen-lab-data \
             | augur curate format-dates \
-                --date-fields {params.date_fields} \
-                --expected-date-formats {params.expected_date_formats} \
+                --date-fields {params.date_fields:q} \
+                --expected-date-formats {params.expected_date_formats:q} \
             | ./build-configs/ncbi/bin/transform-host \
                 --host-map {params.host_map} \
             | ./vendored/apply-geolocation-rules \


### PR DESCRIPTION
## Description of proposed changes

Requested by @trvrb on [Slack](https://bedfordlab.slack.com/archives/CD84ELG0N/p1718129534603179) and just generally useful to include the release date for adding a `recency` coloring in the phylo workflow. 

## Related issue(s)

I should really get back to the issue of explicitly creating a list of [standardized output metadata fields for ingest](https://github.com/nextstrain/pathogen-repo-guide/issues/20)

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
