### PR TITLE
Add GH Action for NCBI phylogenetic workflow

### DIFF
--- a/.github/workflows/phylogenetic-fauna.yaml
+++ b/.github/workflows/phylogenetic-fauna.yaml
@@ -1,4 +1,4 @@
-name: Phylogenetic NCBI
+name: Phylogenetic Fauna
 
 defaults:
   run:
@@ -31,13 +31,9 @@ jobs:
     uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
     secrets: inherit
     with:
-      runtime: docker
+      runtime: aws-batch
       run: |
         declare -a config;
-
-        config+=(
-          s3_src="s3://nextstrain-data/files/workflows/avian-flu/h5n1"
-        );
 
         if [[ "$TRIAL_NAME" ]]; then
           config+=(
@@ -46,12 +42,15 @@ jobs:
         fi;
 
         nextstrain build \
+          --detach \
+          --no-download \
+          --cpus 16 \
+          --memory 28800mib \
           . \
             deploy_all \
-            --snakefile Snakefile.genome \
             --config "${config[@]}"
 
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
         TRIAL_NAME: ${{ inputs.trial-name }}
-      artifact-name: phylogenetic-full-genome-build-output
+      artifact-name: phylogenetic-fauna-build-output

--- a/.github/workflows/phylogenetic-fauna.yaml
+++ b/.github/workflows/phylogenetic-fauna.yaml
@@ -1,0 +1,57 @@
+name: Phylogenetic NCBI
+
+defaults:
+  run:
+    # This is the same as GitHub Action's `bash` keyword as of 20 June 2023:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    #
+    # Completely spelling it out here so that GitHub can't change it out from under us
+    # and we don't have to refer to the docs to know the expected behavior.
+    shell: bash --noprofile --norc -eo pipefail {0}
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: 'Specific container image to use for ingest workflow (will override the default of "nextstrain build")'
+        required: false
+        type: string
+      trial-name:
+        description: |
+          Trial name for deploying builds.
+          If not set, builds will overwrite existing builds at s3://nextstrain-data/avian-flu*
+          If set, builds will be deployed to s3://nextstrain-staging/avian-flu_trials_<trial_name>_*
+        required: false
+        type: string
+
+jobs:
+  phylogenetic:
+    permissions:
+      id-token: write
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    secrets: inherit
+    with:
+      runtime: docker
+      run: |
+        declare -a config;
+
+        config+=(
+          s3_src="s3://nextstrain-data/files/workflows/avian-flu/h5n1"
+        );
+
+        if [[ "$TRIAL_NAME" ]]; then
+          config+=(
+            deploy_url="s3://nextstrain-staging/avian-flu_trials_${TRIAL_NAME}_"
+          )
+        fi;
+
+        nextstrain build \
+          . \
+            deploy_all \
+            --snakefile Snakefile.genome \
+            --config "${config[@]}"
+
+      env: |
+        NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
+        TRIAL_NAME: ${{ inputs.trial-name }}
+      artifact-name: phylogenetic-full-genome-build-output

--- a/.github/workflows/phylogenetic-ncbi.yaml
+++ b/.github/workflows/phylogenetic-ncbi.yaml
@@ -11,6 +11,14 @@ defaults:
 
 on:
   workflow_dispatch:
+    inputs:
+      trial-name:
+        description: |
+          Trial name for deploying builds.
+          If not set, builds will overwrite existing builds at s3://nextstrain-data/avian-flu*
+          If set, builds will be deployed to s3://nextstrain-staging/avian-flu_trials_<trial_name>_*
+        required: false
+        type: string
 
 jobs:
   phylogenetic:
@@ -21,9 +29,24 @@ jobs:
     with:
       runtime: docker
       run: |
-        nextstrain build
+        declare -a config;
+
+        config+=(
+          s3_src="s3://nextstrain-data/files/workflows/avian-flu/h5n1"
+        );
+
+        if [[ "$TRIAL_NAME" ]]; then
+          config+=(
+            deploy_url="s3://nextstrain-staging/avian-flu_trials_${TRIAL_NAME}_"
+          )
+        fi;
+
+        nextstrain build \
           . \
             deploy_all \
             --snakefile Snakefile.genome \
-            --config s3_src=s3://nextstrain-data/files/workflows/avian-flu/h5n1
+            --config "${config[@]}"
+
+      env: |
+        TRIAL_NAME: ${{ inputs.trial-name }}
       artifact-name: phylogenetic-full-genome-build-output

--- a/.github/workflows/phylogenetic-ncbi.yaml
+++ b/.github/workflows/phylogenetic-ncbi.yaml
@@ -1,0 +1,29 @@
+name: Phylogenetic NCBI
+
+defaults:
+  run:
+    # This is the same as GitHub Action's `bash` keyword as of 20 June 2023:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    #
+    # Completely spelling it out here so that GitHub can't change it out from under us
+    # and we don't have to refer to the docs to know the expected behavior.
+    shell: bash --noprofile --norc -eo pipefail {0}
+
+on:
+  workflow_dispatch:
+
+jobs:
+  phylogenetic:
+    permissions:
+      id-token: write
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    secrets: inherit
+    with:
+      runtime: docker
+      run: |
+        nextstrain build
+          . \
+            deploy_all \
+            --snakefile Snakefile.genome \
+            --config s3_src=s3://nextstrain-data/files/workflows/avian-flu/h5n1
+      artifact-name: phylogenetic-full-genome-build-output

--- a/.github/workflows/phylogenetic-ncbi.yaml
+++ b/.github/workflows/phylogenetic-ncbi.yaml
@@ -12,6 +12,10 @@ defaults:
 on:
   workflow_dispatch:
     inputs:
+      image:
+        description: 'Specific container image to use for ingest workflow (will override the default of "nextstrain build")'
+        required: false
+        type: string
       trial-name:
         description: |
           Trial name for deploying builds.
@@ -48,5 +52,6 @@ jobs:
             --config "${config[@]}"
 
       env: |
+        NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
         TRIAL_NAME: ${{ inputs.trial-name }}
       artifact-name: phylogenetic-full-genome-build-output

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ nextstrain build --aws-batch --aws-batch-cpus 16 --aws-batch-memory 28800 . --jo
 
 Please see [nextstrain.org/docs](https://nextstrain.org/docs) for details about augur and pathogen builds.
 
+### Deploying builds
+
+The pipeline can automatically deploy resulting builds within the auspice folder
+to nextstrain.org by running:
+
+```
+nextstrain build . deploy_all
+```
+
 ## Creating a custom build
 The easiest way to generate your own, custom avian-flu build is to use the quickstart-build as a starting template. Simply clone the quickstart-build, run with the example data, and edit the Snakefile to customize. This build includes example data and a simplified, heavily annotated Snakefile that goes over the structure of Snakefiles and annotates rules and inputs/outputs that can be modified. This build, with it's own readme, is available [here](https://github.com/nextstrain/avian-flu/tree/master/quickstart-build).
 

--- a/Snakefile
+++ b/Snakefile
@@ -22,6 +22,9 @@ rule all:
     input:
         auspice_json = all_targets()
 
+# This must be after the `all` rule above since it depends on its inputs
+include: "rules/deploy.smk"
+
 rule test_target:
     """
     For testing purposes such as CI workflows.

--- a/Snakefile.genome
+++ b/Snakefile.genome
@@ -33,6 +33,9 @@ def subtype(build_name):
 rule all:
     input: expand("auspice/avian-flu_{build_name}_genome.json", build_name=BUILD_NAME)
 
+# This must be after the `all` rule above since it depends on its inputs
+include: "rules/deploy.smk"
+
 rule files:
     params:
         reference = lambda w: f"config/reference_{subtype(w.build_name)}_{{segment}}.gb",

--- a/rules/deploy.smk
+++ b/rules/deploy.smk
@@ -1,0 +1,15 @@
+DEPLOY_URL = config.get('deploy_url', "s3://nextstrain-data")
+
+
+rule deploy_all:
+    """
+    Upload all builds to AWS S3
+    Depends on indendent Snakemake workflow's defined `all` rule
+    """
+    input: rules.all.input
+    params:
+        s3_dst = DEPLOY_URL
+    shell:
+        """
+        nextstrain remote upload {params.s3_dst:q} {input}
+        """


### PR DESCRIPTION
## Description of proposed changes

Add GH Action workflows for the phylogenetic builds 

1. The [Phylogenetic NCBI workflow](https://github.com/nextstrain/avian-flu/actions/workflows/phylogenetic-ncbi.yaml) uses the public NCBI data for the full genome build and is able to run completely within the `docker` runtime on GH Actions. 

2. The [Phylogenetic Fauna workflow](https://github.com/nextstrain/avian-flu/actions/workflows/phylogenetic-fauna.yaml) uses the private fauna data for the default builds. I didn't check if it would complete within GH Actions and just followed the README instructions to run via `aws-batch`. 

It's unclear how much manual curation is needed for NCBI ingest data before running builds so both need to be manually triggered for now. 

## Related issue(s)

Resolves https://github.com/nextstrain/avian-flu/issues/60

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Trial NCBI run](https://github.com/nextstrain/avian-flu/actions/runs/9619561058) -> build uploaded to [staging](https://nextstrain.org/staging/avian-flu/trials/gh-action-phylo/avian-flu/h5n1-cattle-outbreak/genome)
- [x] [Trial fauna run](https://github.com/nextstrain/avian-flu/actions/runs/9619984303) -> builds uploaded to [staging](https://nextstrain.org/staging/avian-flu/trials/gh-action-phylo/avian-flu/h5n1/ha/all-time) (follows pattern of `https://nextstrain.org/staging/avian-flu/trials/gh-action-phylo/avian-flu/<subtype>/<segment>/<time>`)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
