### PR TITLE
Update Andersen Lab ingest to new metadata

### DIFF
--- a/ingest/build-configs/ncbi/bin/transform-host
+++ b/ingest/build-configs/ncbi/bin/transform-host
@@ -26,9 +26,13 @@ def parse_host_map(host_map_file: str) -> dict:
     """
     host_map = {}
     with open(host_map_file) as tsv_file:
-        reader = csv.DictReader(tsv_file, delimiter="\t")
+        reader = csv.reader(tsv_file, delimiter="\t")
         for row in reader:
-            host_map[row["old_name"].lower()] = row["new_name"]
+            # Skip comments
+            if not row or row[0].lstrip()[0] == '#':
+                continue
+
+            host_map[row[0].lower()] = row[1]
 
     return host_map
 

--- a/ingest/build-configs/ncbi/defaults/annotations.tsv
+++ b/ingest/build-configs/ncbi/defaults/annotations.tsv
@@ -8,3 +8,5 @@ A/environment/USA/CO-UW-9084466/2024	division	Colorado # Based on linked BioSamp
 A/environment/USA/CO-UW-9084466/2024	host	Cattle # This sequence from commercial milk is definitively from cattle, strain name guidelines are going to be updated here
 A/ALPACA/USA/24-014328-007/2024	division	Idaho # Based on news reports https://www.cidrap.umn.edu/avian-influenza-bird-flu/alpacas-infected-h5n1-avian-flu-idaho
 A/Alpaca/USA/24-015080-001/2024	division	Idaho # Based on news reports https://www.cidrap.umn.edu/avian-influenza-bird-flu/alpacas-infected-h5n1-avian-flu-idaho
+A/House-Mouse/USA/24-014780-002/2024	division	New Mexico # Based on https://wahis.woah.org/#/in-review/4451?reportId=167771&fromPage=event-dashboard-url
+A/House-Mouse/USA/24-014782-003/2024	division	New Mexico # Based on https://wahis.woah.org/#/in-review/4451?reportId=167771&fromPage=event-dashboard-url

--- a/ingest/build-configs/ncbi/defaults/host-map.tsv
+++ b/ingest/build-configs/ncbi/defaults/host-map.tsv
@@ -50,6 +50,8 @@ harris hawk	Avian
 harris-hawk	Avian
 hawk	Avian
 Homo sapiens	Human
+HOSP	Environment
+House-Mouse	Nonhuman Mammal
 Icteridae	Avian
 Larus occidentalis	Avian
 Lophodytes cucullatus	Avian

--- a/ingest/build-configs/ncbi/defaults/host-map.tsv
+++ b/ingest/build-configs/ncbi/defaults/host-map.tsv
@@ -1,4 +1,4 @@
-old_name	new_name
+# Check for bird codes in https://www.carolinabirdclub.org/bandcodes.html
 alpaca	Nonhuman Mammal
 american crow	Avian
 american wigeon	Avian
@@ -50,7 +50,7 @@ harris hawk	Avian
 harris-hawk	Avian
 hawk	Avian
 Homo sapiens	Human
-HOSP	Environment
+HOSP	Avian
 House-Mouse	Nonhuman Mammal
 Icteridae	Avian
 Larus occidentalis	Avian

--- a/ingest/build-configs/ncbi/rules/ingest_andersen_lab.smk
+++ b/ingest/build-configs/ncbi/rules/ingest_andersen_lab.smk
@@ -39,9 +39,9 @@ rule extract_automated_metadata:
     input:
         andersen_lab_repo = "andersen-lab/data/avian-influenza.tar.gz"
     output:
-        metadata = "andersen-lab/data/PRJNA1102327_automated_metadata.csv"
+        metadata = "andersen-lab/data/SraRunTable_automated_metadata.csv",
     params:
-        metadata_file_path = "metadata/SraRunTable_PRJNA1102327_automated.csv",
+        metadata_file_path = "metadata/SraRunTable_automated.csv",
     shell:
         """
         tar xz -O --file={input.andersen_lab_repo} \
@@ -58,9 +58,9 @@ rule join_old_and_automated_metadata:
     """
     input:
         old_metadata = "andersen-lab/data/PRJNA1102327_old_metadata.csv",
-        automated_metadata = "andersen-lab/data/PRJNA1102327_automated_metadata.csv",
+        automated_metadata = "andersen-lab/data/SraRunTable_automated_metadata.csv",
     output:
-        metadata = "andersen-lab/data/PRJNA1102327_metadata.csv",
+        metadata = "andersen-lab/data/raw_metadata.csv",
     params:
         join_field = "Run",
     shell:
@@ -114,7 +114,7 @@ rule rename_and_concatenate_segment_fastas:
 
 rule curate_metadata:
     input:
-        metadata = "andersen-lab/data/PRJNA1102327_metadata.csv",
+        metadata = "andersen-lab/data/raw_metadata.csv",
         geolocation_rules = "defaults/geolocation_rules.tsv",
         annotations=config["curate"]["annotations"],
     output:


### PR DESCRIPTION
## Description of proposed changes

Update the Andersen Lab ingest workflow to use the latest metadata file that includes SRA runs from multiple BioProjects.

## Related issue(s)

Flagged by @trvrb on [Slack](https://bedfordlab.slack.com/archives/CD84ELG0N/p1719349165673599) that the Andersen Lab repo has started using a new metadata file that now includes multiple BioProjects.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Trial ingest workflow](https://github.com/nextstrain/avian-flu/actions/runs/9670599759) -> results uploaded to `s3://nextstrain-data/files/workflows/avian-flu/trial/update-andersen/h5n1/`

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
