### PR TITLE
Segment builds for H5N1 cattle flu outbreak 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ nextstrain build \
     . \
         --config s3_src=s3://nextstrain-data/files/workflows/avian-flu/h5n1 \
         -pf \
-        auspice/avian-flu_h5n1-cattle-outbreak_pb2_all-time.json \
-        auspice/avian-flu_h5n1-cattle-outbreak_pb1_all-time.json \
-        auspice/avian-flu_h5n1-cattle-outbreak_pa_all-time.json \
-        auspice/avian-flu_h5n1-cattle-outbreak_ha_all-time.json \
-        auspice/avian-flu_h5n1-cattle-outbreak_np_all-time.json \
-        auspice/avian-flu_h5n1-cattle-outbreak_na_all-time.json \
-        auspice/avian-flu_h5n1-cattle-outbreak_mp_all-time.json \
-        auspice/avian-flu_h5n1-cattle-outbreak_ns_all-time.json
+        auspice/avian-flu_h5n1-cattle-outbreak_pb2.json \
+        auspice/avian-flu_h5n1-cattle-outbreak_pb1.json \
+        auspice/avian-flu_h5n1-cattle-outbreak_pa.json \
+        auspice/avian-flu_h5n1-cattle-outbreak_ha.json \
+        auspice/avian-flu_h5n1-cattle-outbreak_np.json \
+        auspice/avian-flu_h5n1-cattle-outbreak_na.json \
+        auspice/avian-flu_h5n1-cattle-outbreak_mp.json \
+        auspice/avian-flu_h5n1-cattle-outbreak_ns.json
 ```
 
 ## Creating a custom build

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # nextstrain.org/avian-flu
 
-This is the Nextstrain build for avian influenza subtypes A/H5N1, A/H5NX, A/H7N9, and A/H9N2.
+This is the Nextstrain build for avian influenza subtypes A/H5N1, A/H5NX, A/H7N9, and A/H9N2 as well as analysis of the 2024 A/H5N1 cattle-flu outbreak.
 The most up-to-date builds of avian influenza can be found [on nextstrain.org](https://nextstrain.org/avian-flu).
 Please see [nextstrain.org/docs](https://nextstrain.org/docs) for details about augur and pathogen builds.
 
-## Building
+## Segment-level GISAID builds
 
-All 32 builds (4 subtypes x 8 segments) can be built by running `snakemake`.
+The default Snakemake pipeline builds 32 Auspice datasets (8 segments x 4 subtypes (A/H5N1, A/H5NX, A/H7N9, A/H9N2)),
+and can be run via `snakemake` with no config overrides. 
 This pipeline starts by downloading data from a private S3 bucket and the appropriate credentials are required; see below for how to use locally ingested files.
 For rapid AWS rebuild run as:
 
@@ -25,10 +26,57 @@ to nextstrain.org by running:
 nextstrain build . deploy_all
 ```
 
+## H5N1 Cattle Outbreak (2024)
+
+We produce per-segment and whole-genome (concatenated segments) builds for the ongoing H5N1 cattle-flu outbreak.
+These use NCBI data including consensus genomes and SRA data assembled via the Andersen lab's [avian-influenza repo](https://github.com/andersen-lab/avian-influenza).
+
+> Running this build will overwrite GISAID files in `./data` and thus you can't maintain or run GISAID & NCBI builds in parallel. In most cases this isn't an issue and [we are working on improving this](https://github.com/nextstrain/avian-flu/issues/70). You may want to proactively remove the `./data` directory yourself to make sure everything works as expected.
+
+#### Whole genome build
+
+An up-to-date version of this build is available at [nextstrain.org/avian-flu/h5n1-cattle-outbreak/genome](https://nextstrain.org/avian-flu/h5n1-cattle-outbreak/genome).
+
+``` bash
+nextstrain build \
+    --env AWS_ACCESS_KEY_ID \
+    --env AWS_SECRET_ACCESS_KEY \
+    . \
+        --snakefile Snakefile.genome \
+        --config s3_src=s3://nextstrain-data/files/workflows/avian-flu/h5n1
+```
+
+The build is restricted to a set of strains where we think there's no reassortment, with outgroups excluded (`config/dropped_strains_h5n1-cattle-outbreak.txt`).
+Output files will be placed in `results/h5n1-cattle-outbreak/genome`.
+See `Snakefile.genome` for more details.
+
+#### Segment-level builds
+
+Strains for each segment are chosen by first constructing a general tree for the segment with all strains from 2024 onwards and then taking the clade which contains all strains in the genome build.
+This should allow any reassortments to be highlighted and will also include outbreak strains which are missing from the genome build (because they don't have all 8 segments sequenced).
+
+
+``` bash
+nextstrain build \
+    --env AWS_ACCESS_KEY_ID \
+    --env AWS_SECRET_ACCESS_KEY \
+    . \
+        --config s3_src=s3://nextstrain-data/files/workflows/avian-flu/h5n1 \
+        -pf \
+        auspice/avian-flu_h5n1-cattle-outbreak_pb2_all-time.json \
+        auspice/avian-flu_h5n1-cattle-outbreak_pb1_all-time.json \
+        auspice/avian-flu_h5n1-cattle-outbreak_pa_all-time.json \
+        auspice/avian-flu_h5n1-cattle-outbreak_ha_all-time.json \
+        auspice/avian-flu_h5n1-cattle-outbreak_np_all-time.json \
+        auspice/avian-flu_h5n1-cattle-outbreak_na_all-time.json \
+        auspice/avian-flu_h5n1-cattle-outbreak_mp_all-time.json \
+        auspice/avian-flu_h5n1-cattle-outbreak_ns_all-time.json
+```
+
 ## Creating a custom build
 The easiest way to generate your own, custom avian-flu build is to use the quickstart-build as a starting template. Simply clone the quickstart-build, run with the example data, and edit the Snakefile to customize. This build includes example data and a simplified, heavily annotated Snakefile that goes over the structure of Snakefiles and annotates rules and inputs/outputs that can be modified. This build, with it's own readme, is available [here](https://github.com/nextstrain/avian-flu/tree/master/quickstart-build).
 
-### Features unique to avian flu builds
+## Features unique to avian flu builds
 
 #### cleavage site annotations
 Influenza virus HA is translated as a single peptide (HA0) that is cleaved to form the mature, functional form (HA1 and HA2). In all human strains and many avian strains, the cleavage site is composed of a single, basic amino acid residue. However, some avian influenza subtypes, particularly H5s, have acquired additional basic residues immediately preceding the HA cleavage site. In some cases, this results in addition of a furin cleavage motif, allowing HA to be cleaved by furin, which is ubiquitously expressed, and allows for viral replication across a range of tissues. The addition of this "polybasic cleavage site" is one of the prime determinants of avian influenza virulence. In these builds, we have annotated whether strains contain a furin cleavage motif, defined here as the sequence `R-X-K/R-R` immediately preceding the start of HA2, where `X` can be any amino acid. We have also added a color by for the cleavage site sequence, which we define here as the 4 bases preceding HA2.
@@ -71,26 +119,6 @@ Note that you may need to remove any existing data in `results/` in order for sn
 
 Run the pipeline with `--config 'local_ingest=True'` to use the locally available files produced by the ingest pipeline (see `./ingest/README.md` for details on how to run).
 Specifically, the files needed are `ingest/results/metadata.tsv` and `ingest/results/sequences_{SEGMENT}.fasta`.
-
-
-#### Running full genome builds
-
-Run full genome builds with the following command.
-
-``` bash
-nextstrain build \
-    --env AWS_ACCESS_KEY_ID \
-    --env AWS_SECRET_ACCESS_KEY \
-    . \
-        --snakefile Snakefile.genome \
-        --config s3_src=s3://nextstrain-data/files/workflows/avian-flu/h5n1
-```
-
-Currently this is only set up for the "h5n1-cattle-outbreak" build using NCBI data,
-and the build is restricted to a set of strains where we think there's no reassortment, with outgroups
-excluded in (`config/dropped_strains_h5n1-cattle-outbreak.txt`).
-Output files will be placed in `results/h5n1-cattle-outbreak/genome`.
-See `Snakefile.genome` for more details.
 
 
 ### To modify this build to work with your own data

--- a/Snakefile
+++ b/Snakefile
@@ -203,6 +203,8 @@ rule align:
         reference = files.reference
     output:
         alignment = "results/aligned_{subtype}_{segment}_{time}.fasta"
+    threads:
+        4
     shell:
         """
         augur align \
@@ -210,7 +212,7 @@ rule align:
             --reference-sequence {input.reference} \
             --output {output.alignment} \
             --remove-reference \
-            --nthreads 1
+            --nthreads {threads}
         """
 
 
@@ -222,13 +224,15 @@ rule tree:
         tree = "results/tree-raw_{subtype}_{segment}_{time}.nwk"
     params:
         method = "iqtree"
+    threads:
+        4
     shell:
         """
         augur tree \
             --alignment {input.alignment} \
             --output {output.tree} \
             --method {params.method} \
-            --nthreads 1
+            --nthreads {threads}
         """
 
 rule refine:

--- a/rules/cattle-flu.smk
+++ b/rules/cattle-flu.smk
@@ -11,7 +11,7 @@ rule download_tree:
         dataset="https://data.nextstrain.org/avian-flu_h5n1-cattle-outbreak_genome.json"
     wildcard_constraints:
         subtype="h5n1-cattle-outbreak",
-        time="all-time",
+        time="default",
     shell:
         """
         curl --compressed {params.dataset} -o {output.tree}
@@ -27,7 +27,7 @@ rule prune_tree:
         node_data = "results/tree_{subtype}_{segment}_{time}_outbreak-clade.json",
     wildcard_constraints:
         subtype="h5n1-cattle-outbreak",
-        time="all-time",
+        time="default",
     shell:
         """
         python3 scripts/restrict-via-common-ancestor.py \

--- a/rules/cattle-flu.smk
+++ b/rules/cattle-flu.smk
@@ -1,0 +1,38 @@
+
+rule download_tree:
+    """
+    Downloads the tree behind nextstrain.org/avian-flu/h5n1-cattle-outbreak/genome
+    so that the segment-level builds can use it to restrict the strains used.
+    TODO: if the whole-genome analysis has been run locally we should (optionally) use that tree.
+    """
+    output:
+        tree = "results/tree_{subtype}_genome.json",
+    params:
+        dataset="https://data.nextstrain.org/avian-flu_h5n1-cattle-outbreak_genome.json"
+    wildcard_constraints:
+        subtype="h5n1-cattle-outbreak",
+        time="all-time",
+    shell:
+        """
+        curl --compressed {params.dataset} -o {output.tree}
+        """
+
+
+rule prune_tree:
+    input:
+        tree = "results/tree_{subtype}_{segment}_{time}.nwk",
+        strains = "results/tree_{subtype}_genome.json",
+    output:
+        tree = "results/tree_{subtype}_{segment}_{time}_outbreak-clade.nwk",
+        node_data = "results/tree_{subtype}_{segment}_{time}_outbreak-clade.json",
+    wildcard_constraints:
+        subtype="h5n1-cattle-outbreak",
+        time="all-time",
+    shell:
+        """
+        python3 scripts/restrict-via-common-ancestor.py \
+            --tree {input.tree} \
+            --strains {input.strains} \
+            --output-tree {output.tree} \
+            --output-metadata {output.node_data}
+        """

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -10,6 +10,7 @@ def subtypes_by_subtype_wildcard(wildcards):
         'h7n9': ['h7n9'],
         'h9n2': ['h9n2'],
     }
+    db['h5n1-cattle-outbreak'] = [*db['h5nx']]
     return(db[wildcards.subtype])
 
 if LOCAL_INGEST:

--- a/scripts/restrict-via-common-ancestor.py
+++ b/scripts/restrict-via-common-ancestor.py
@@ -1,0 +1,83 @@
+"""
+Returns a monophyletic clade from the provided tree which encompasses all the (terminal)
+strains provided via a list or an Auspice dataset.
+"""
+
+import argparse
+import json
+from Bio import Phylo
+from sys import exit, stderr
+from typing import cast, Set, Dict, Any
+from augur.io import read_strains
+
+
+def strains_in_auspice_json(fname: str) -> Set[str]:
+    with open(fname) as fh:
+        j = json.load(fh)
+    assert isinstance(j['tree'], dict), "Only supports datasets with a single dataset"
+    strains = set()
+    nodes = [j['tree']]
+    while len(nodes):
+        node = nodes.pop(0)
+        children = node.get("children", [])
+        nodes.extend(children)
+        if not children:
+            strains.add(node['name'])
+    return strains
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--tree', type=str, metavar="NEWICK", required=True, help="Input tree")
+    parser.add_argument('--strains', type=str, metavar="TXT|JSON", required = True,
+        help="A list of strains or Auspice JSON whose strains are used to define the common ancestor")
+    parser.add_argument('--output-tree', type=str, metavar="NEWICK", required = True, help="output tree")
+    parser.add_argument('--output-metadata', type=str, metavar="JSON", help="output node-data JSON")
+    args = parser.parse_args()
+
+
+    tree = Phylo.read(args.tree, "newick")
+    if args.strains.lower().endswith(".txt"):
+        all_defining_strains = cast(Set[str], read_strains(args.strains))
+    elif args.strains.lower().endswith(".json"):        
+        all_defining_strains = strains_in_auspice_json(args.strains)
+    else:
+        print("Unknown format of '--strains' - must be .txt or .json", file=stderr)
+        exit(2)
+
+    print(f"Defining strains in input strains: {len(all_defining_strains)}")
+    defining_strains = [node for node in tree.get_terminals() if node.name in all_defining_strains]
+    print(f"Defining strains found in input tree: {len(defining_strains)}")
+    # print("DEFINING STRAINS IN TREE", defining_strains)
+
+    if len(defining_strains)<2:
+        print("ERROR: Not enough defining strains", file=stderr)
+        exit(2)
+
+    ca = tree.common_ancestor(defining_strains)
+    print(f"Input tree root node: {tree.root.name!r}, num tips: {len(tree.get_terminals())}")
+    print(f"Restricted tree root node: {ca.name!r}, num tips: {len(ca.get_terminals())}")
+
+    # TODO -- (the root of) `ca` may be part of a polytomy when viewed using divergence, and if so we probably
+    # want to walk up the tree and return the entire polytomy. This is consistent with the general idea of
+    # returning terminal nodes which may be basal to the "true" cattle-flu outbreak
+
+    Phylo.write(ca, args.output_tree, "newick")
+
+    if (args.output_metadata):
+        meta: Dict[str, Any] = {"nodes": {}}
+        # TODO add "generated_by" section once <https://github.com/nextstrain/augur/issues/1476>
+        # is resolved
+
+        for node in ca.get_terminals():
+            # booleans don't flow nicely through to Auspice so use strings here
+            meta['nodes'][node.name] = {'genome_tree': "Yes" if node.name in all_defining_strains else "No"}
+
+        # document the strains in the genome tree (--strains) but which are missing from the
+        # input tree. Ideally there are none!
+        strains_in_tree = set([node.name for node in ca.get_terminals()])
+        meta['nodes']['extensions'] = {
+            'genome_strains_missing_from_segment_tree': [x for x in all_defining_strains if x not in strains_in_tree]
+        }
+
+        with open(args.output_metadata, 'w') as fh:
+            json.dump(meta, fh)


### PR DESCRIPTION
Individual datasets for all 8 segments are added using NCBI data
(consistent with the whole-genome view) and using the strains included
in the genome tree to choose the appropriate monophyletic clade in each
segment tree to include.

There is an added Auspice colouring "genome_tree" which indicates
whether the strain exists in the whole genome tree.

See top-level README for instructions on how to run.

There are a number of important caveats with the current implementation,
all of which are fixable but I think better done in future work.

* The input source must be NCBI for this build to work as expected and
thus the `s3_src` config argument is essential. I think Snakemake will
not reuse existing files in `./data` if they originated from a
different source (e.g. GISAID), despite their filenames being
identical, but I am not 100% sure. I've advised removing the `data`
directory in the README to be safe.

* The filenames produced include "_all-time" as the current Snakemake
workflow requires a "time" wildcard, however we want to remove this
prior to uploading. E.g.
`auspice/avian-flu_h5n1-cattle-outbreak_ha_all-time.json` should be
uploaded to /avian-flu/h5n1-cattle-outbreak/ha to match the URL
structure for the genome build. We can use the following bash one-liner
prior to uploading while this remains unfixed:
```
for i in auspice/avian-flu_h5n1-cattle-outbreak_*_all-time.json; do mv $i ${i%_all-time.json}.json; done
```

* The segment builds may include basal strains which aren't part of the
  cattle-flu outbreak but are included because there aren't mutations
  which distinguish them from others which should be. The "genome_tree"
  colouring is helpful here. (See the note in
  `restrict-via-common-ancestor.py` -- we may want to include more basal
  strains here).

---

Datasets are available at [staging/avian-flu/h5n1-cattle-outbreak/ha](https://nextstrain.org/staging/avian-flu/h5n1-cattle-outbreak/ha) (for each segment)

---

Looking at the temporally resolved segment trees (LHS) vs the current genome tree, and colouring by the presense of each strain in the whole-genome build:


HA has some extra strains within the clade (and also pulls in some basal strains which look like they're not part of the outbreak based on their host, but may be important). The temporal resolution isn't as good (as expected), and this is seen in all segment trees.

<img width="1068" alt="image" src="https://github.com/nextstrain/avian-flu/assets/8350992/88559738-449e-4638-bab8-fe0ce83bef58">

MP pulls in a bunch of basal strains due to the `A/skunk/NewMexico/24-006483-001/2024` strain we're using as an outgroup. 

<img width="1076" alt="image" src="https://github.com/nextstrain/avian-flu/assets/8350992/a1bde440-af55-41e1-b899-640f7aa536d3">


---

- [ ] Checks pass
