### PR TITLE
Automate NCBI ingest to phylo workflow

### DIFF
--- a/.github/workflows/ingest-ncbi.yaml
+++ b/.github/workflows/ingest-ncbi.yaml
@@ -10,26 +10,12 @@ defaults:
     shell: bash --noprofile --norc -eo pipefail {0}
 
 on:
-  schedule:
-    # Note times are in UTC, which is 1 or 2 hours behind CET depending on daylight savings.
-    #
-    # Note the actual runs might be late.
-    # Numerous people were confused, about that, including me:
-    #  - https://github.community/t/scheduled-action-running-consistently-late/138025/11
-    #  - https://github.com/github/docs/issues/3059
-    #
-    # Note, '*' is a special character in YAML, so you have to quote this string.
-    #
-    # Docs:
-    #  - https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
-    #
-    # Tool that deciphers this particular format of crontab string:
-    #  - https://crontab.guru/
-    #
-    # Runs at 5pm UTC (1pm EDT/10am PDT) since curation by NCBI happens on the East Coast.
-    # We were running into invalid zip archive errors at 9am PDT, so hoping an hour
-    # delay will lower the error frequency
-    - cron: '0 17 * * *'
+  workflow_call:
+    inputs:
+      image:
+        description: 'Specific container image to use for ingest workflow (will override the default of "nextstrain build")'
+        required: false
+        type: string
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/ingest-to-phylogenetic-ncbi.yaml
+++ b/.github/workflows/ingest-to-phylogenetic-ncbi.yaml
@@ -44,7 +44,7 @@ jobs:
   ingest:
     permissions:
       id-token: write
-    uses: ./.github/workflows/ingest.yaml
+    uses: ./.github/workflows/ingest-ncbi.yaml
     secrets: inherit
     with:
       image: ${{ inputs.ingest_image }}
@@ -64,10 +64,22 @@ jobs:
         env:
           AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
         run: |
-          s3_urls=(
-            "s3://nextstrain-data/files/workflows/zika/metadata.tsv.zst"
-            "s3://nextstrain-data/files/workflows/zika/sequences.fasta.zst"
+          segments=(
+            'ha'
+            'mp'
+            'na'
+            'np'
+            'ns'
+            'pa'
+            'pb1'
+            'pb2'
           )
+
+          s3_urls=("s3://nextstrain-data/files/workflows/avian-flu/h5n1/metadata.tsv.zst")
+
+          for segment in "${segments[@]}"; do
+            s3_urls+=("s3://nextstrain-data/files/workflows/avian-flu/h5n1/${segment}/sequences.fasta.zst")
+          done
 
           # Code below is modified from ingest/upload-to-s3
           # https://github.com/nextstrain/ingest/blob/c0b4c6bb5e6ccbba86374d2c09b42077768aac23/upload-to-s3#L23-L29
@@ -80,7 +92,7 @@ jobs:
             key="${s3path#*/}"
 
             s3_hash="$(aws s3api head-object --no-sign-request --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
-            echo "${s3_hash}" | tee -a ingest-output-sha256sum
+            echo "${s3_hash}" | tee -a ingest-ncbi-output-sha256sum
           done
 
       - name: Check cache
@@ -88,7 +100,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ingest-output-sha256sum
-          key: ingest-output-sha256sum-${{ hashFiles('ingest-output-sha256sum') }}
+          key: ingest-output-sha256sum-${{ hashFiles('ingest-ncbi-output-sha256sum') }}
           lookup-only: true
 
   phylogenetic:
@@ -96,7 +108,7 @@ jobs:
     if: ${{ needs.check-new-data.outputs.cache-hit != 'true' }}
     permissions:
       id-token: write
-    uses: ./.github/workflows/phylogenetic.yaml
+    uses: ./.github/workflows/phylogenetic-ncbi.yaml
     secrets: inherit
     with:
       image: ${{ inputs.phylogenetic_image }}

--- a/.github/workflows/ingest-to-phylogenetic-ncbi.yaml
+++ b/.github/workflows/ingest-to-phylogenetic-ncbi.yaml
@@ -1,0 +1,102 @@
+name: Ingest to phylogenetic
+
+defaults:
+  run:
+    # This is the same as GitHub Action's `bash` keyword as of 20 June 2023:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    #
+    # Completely spelling it out here so that GitHub can't change it out from under us
+    # and we don't have to refer to the docs to know the expected behavior.
+    shell: bash --noprofile --norc -eo pipefail {0}
+
+on:
+  schedule:
+    # Note times are in UTC, which is 1 or 2 hours behind CET depending on daylight savings.
+    #
+    # Note the actual runs might be late.
+    # Numerous people were confused, about that, including me:
+    #  - https://github.community/t/scheduled-action-running-consistently-late/138025/11
+    #  - https://github.com/github/docs/issues/3059
+    #
+    # Note, '*' is a special character in YAML, so you have to quote this string.
+    #
+    # Docs:
+    #  - https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#schedule
+    #
+    # Tool that deciphers this particular format of crontab string:
+    #  - https://crontab.guru/
+    #
+    # Runs at 5pm UTC (1pm EDT/10am PDT) since curation by NCBI happens on the East Coast.
+    # We were running into invalid zip archive errors at 9am PDT, so hoping an hour
+    # delay will lower the error frequency
+    - cron: '0 17 * * *'
+
+  workflow_dispatch:
+    inputs:
+      ingest_image:
+        description: 'Specific container image to use for ingest workflow (will override the default of "nextstrain build")'
+        required: false
+      phylogenetic_image:
+        description: 'Specific container image to use for phylogenetic workflow (will override the default of "nextstrain build")'
+        required: false
+
+jobs:
+  ingest:
+    permissions:
+      id-token: write
+    uses: ./.github/workflows/ingest.yaml
+    secrets: inherit
+    with:
+      image: ${{ inputs.ingest_image }}
+
+  # Check if ingest results include new data by checking for the cache
+  # of the file with the results' Metadata.sh256sum (which should have been added within upload-to-s3)
+  # GitHub will remove any cache entries that have not been accessed in over 7 days,
+  # so if the workflow has not been run over 7 days then it will trigger phylogenetic.
+  check-new-data:
+    needs: [ingest]
+    runs-on: ubuntu-latest
+    outputs:
+      cache-hit: ${{ steps.check-cache.outputs.cache-hit }}
+    steps:
+      - name: Get sha256sum
+        id: get-sha256sum
+        env:
+          AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
+        run: |
+          s3_urls=(
+            "s3://nextstrain-data/files/workflows/zika/metadata.tsv.zst"
+            "s3://nextstrain-data/files/workflows/zika/sequences.fasta.zst"
+          )
+
+          # Code below is modified from ingest/upload-to-s3
+          # https://github.com/nextstrain/ingest/blob/c0b4c6bb5e6ccbba86374d2c09b42077768aac23/upload-to-s3#L23-L29
+
+          no_hash=0000000000000000000000000000000000000000000000000000000000000000
+
+          for s3_url in "${s3_urls[@]}"; do
+            s3path="${s3_url#s3://}"
+            bucket="${s3path%%/*}"
+            key="${s3path#*/}"
+
+            s3_hash="$(aws s3api head-object --no-sign-request --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
+            echo "${s3_hash}" | tee -a ingest-output-sha256sum
+          done
+
+      - name: Check cache
+        id: check-cache
+        uses: actions/cache@v4
+        with:
+          path: ingest-output-sha256sum
+          key: ingest-output-sha256sum-${{ hashFiles('ingest-output-sha256sum') }}
+          lookup-only: true
+
+  phylogenetic:
+    needs: [check-new-data]
+    if: ${{ needs.check-new-data.outputs.cache-hit != 'true' }}
+    permissions:
+      id-token: write
+    uses: ./.github/workflows/phylogenetic.yaml
+    secrets: inherit
+    with:
+      image: ${{ inputs.phylogenetic_image }}

--- a/.github/workflows/phylogenetic-ncbi.yaml
+++ b/.github/workflows/phylogenetic-ncbi.yaml
@@ -10,6 +10,13 @@ defaults:
     shell: bash --noprofile --norc -eo pipefail {0}
 
 on:
+  workflow_call:
+    inputs:
+      image:
+        description: 'Specific container image to use for phylogenetic workflow (will override the default of "nextstrain build")'
+        required: false
+        type: string
+
   workflow_dispatch:
     inputs:
       image:


### PR DESCRIPTION
## Description of proposed changes

Adds a new GH Action workflow to automate the NCBI h5n1-cattle-outbreak build. 

The build gets triggered if ingest pulls in new metadata and/or sequences. This does a check of the file hashes across all 8 segment FASTAs so there's a possibility of builds getting triggered even if not all 8 segments were added. I think that's _fine_ since we will be adding segment specific builds in #69 anyways. 

## Related issue(s)

Resolves #68 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [ingest-to-phylogenetic-ncbi run](https://github.com/nextstrain/avian-flu/actions/runs/9883077284)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
