### PR TITLE
De-duplicate NCBI strain

### DIFF
--- a/ingest/build-configs/ncbi/defaults/config.yaml
+++ b/ingest/build-configs/ncbi/defaults/config.yaml
@@ -141,3 +141,4 @@ join_ncbi_andersen:
   source_column_name: data_source
   ncbi_source: genbank
   andersen_source: sra-via-andersen-lab
+  dedup_column: strain

--- a/ingest/build-configs/ncbi/rules/ingest_andersen_lab.smk
+++ b/ingest/build-configs/ncbi/rules/ingest_andersen_lab.smk
@@ -131,6 +131,7 @@ rule curate_metadata:
         augur curate normalize-strings \
             --metadata {input.metadata} \
             | ./build-configs/ncbi/bin/curate-andersen-lab-data \
+            | ./build-configs/ncbi/bin/dedup-by-strain \
             | augur curate format-dates \
                 --date-fields {params.date_fields:q} \
                 --expected-date-formats {params.expected_date_formats:q} \

--- a/ingest/build-configs/ncbi/rules/join_ncbi_andersen.smk
+++ b/ingest/build-configs/ncbi/rules/join_ncbi_andersen.smk
@@ -65,12 +65,14 @@ rule append_missing_metadata_to_ncbi:
         source_column_name = config["join_ncbi_andersen"]["source_column_name"],
         ncbi_source = config["join_ncbi_andersen"]["ncbi_source"],
         andersen_source = config["join_ncbi_andersen"]["andersen_source"],
+        dedup_column = config["join_ncbi_andersen"]["dedup_column"],
     shell:
         """
         tsv-append \
             --source-header {params.source_column_name} \
             --file {params.ncbi_source}={input.ncbi_metadata} \
             --file {params.andersen_source}={input.missing_metadata} \
+            | tsv-uniq -H -f {params.dedup_column} \
             > {output.joined_metadata}
         """
 
@@ -83,5 +85,7 @@ rule append_missing_sequences_to_ncbi:
         joined_sequences = "joined-ncbi/results/sequences_{segment}.fasta",
     shell:
         """
-        cat {input.ncbi_sequences} {input.missing_sequences} > {output.joined_sequences}
+        cat {input.ncbi_sequences} {input.missing_sequences} \
+            | seqkit rmdup \
+            > {output.joined_sequences}
         """


### PR DESCRIPTION
## Description of proposed changes

De-duplicate records by strain name in both the Andersen lab ingest and the final join of NCBI and Andersen lab data.

This is necessary because we depend on the strain name to match metadata and sequences in the phylogenetic workflow. 

## Related issue(s)

Resolves #77 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
