### PR TITLE
Define path_to_fauna in config

### DIFF
--- a/ingest/README.md
+++ b/ingest/README.md
@@ -5,7 +5,8 @@ This is the ingest pipeline for avian virus sequences.
 ## Software requirements
 
 Follow the [standard installation instructions](https://docs.nextstrain.org/en/latest/install.html) for Nextstrain's suite of software tools.
-This workflow requires the Nextstrain CLI's Docker runtime which includes [fauna](https://github.com/nextstrain/fauna) as a sibling directory of the workflow directory and includes the Python RethinkDB bindings required for downloading from fauna.
+This workflow presumes that we are using the Nextstrain CLI's Docker runtime which includes [fauna](https://github.com/nextstrain/fauna) as a sibling directory of the workflow directory and includes the Python RethinkDB bindings required for downloading from fauna.
+
 
 ## Usage
 
@@ -84,6 +85,11 @@ nextstrain build \
 
 This command produces one metadata file, `fauna/results/metadata.tsv`, and one sequences file per gene segment like `fauna/results/sequences_ha.fasta`.
 Each file represents all available subtypes.
+
+> If you are running this outside of Docker you'll need to define the location of fauna via the `path_to_fauna` config option.
+  The path is relative to the 'ingest' directory.
+  Adding `--config path_to_fauna="../../fauna"` works if your fauna directory is a sister directory to the avian-flu repo itself, which is a common set up.
+  
 
 Add the `upload_all` target to the command above to run the complete ingest pipeline _and_ upload results to AWS S3.
 The workflow compresses and uploads the local files to S3 to corresponding paths like `s3://nextstrain-data-private/files/workflows/avian-flu/metadata.tsv.zst` and `s3://nextstrain-data-private/files/workflows/avian-flu/ha/sequences.fasta.zst`.

--- a/ingest/README.md
+++ b/ingest/README.md
@@ -86,10 +86,8 @@ nextstrain build \
 This command produces one metadata file, `fauna/results/metadata.tsv`, and one sequences file per gene segment like `fauna/results/sequences_ha.fasta`.
 Each file represents all available subtypes.
 
-> If you are running this outside of Docker you'll need to define the location of fauna via the `path_to_fauna` config option.
-  The path is relative to the 'ingest' directory.
-  Adding `--config path_to_fauna="../../fauna"` works if your fauna directory is a sister directory to the avian-flu repo itself, which is a common set up.
-  
+> If you are running this outside of Docker we expect 'fauna' to be a sister directory to 'avian-flu'.
+  You can change this via `--config path_to_fauna=<path>` where the path is relative to the 'ingest' directory.
 
 Add the `upload_all` target to the command above to run the complete ingest pipeline _and_ upload results to AWS S3.
 The workflow compresses and uploads the local files to S3 to corresponding paths like `s3://nextstrain-data-private/files/workflows/avian-flu/metadata.tsv.zst` and `s3://nextstrain-data-private/files/workflows/avian-flu/ha/sequences.fasta.zst`.

--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -1,5 +1,3 @@
-path_to_fauna = '../fauna'
-
 # Use default configuration values. Override with Snakemake's --configfile/--config options.
 configfile: "defaults/config.yaml"
 

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -11,4 +11,4 @@ segments:
 s3_dst:
   fauna: s3://nextstrain-data-private/files/workflows/avian-flu
 
-path_to_fauna: ../fauna
+path_to_fauna: ../../fauna

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -10,3 +10,5 @@ segments:
 
 s3_dst:
   fauna: s3://nextstrain-data-private/files/workflows/avian-flu
+
+path_to_fauna: ../fauna

--- a/ingest/rules/ingest_fauna.smk
+++ b/ingest/rules/ingest_fauna.smk
@@ -1,5 +1,10 @@
 from pathlib import Path
 
+def path_to_fauna(w):
+    try:
+        return config["path_to_fauna"]
+    except KeyError:
+        raise Exception("Your config must define 'path_to_fauna'")
 
 rule download_segment:
     output:
@@ -8,11 +13,12 @@ rule download_segment:
         fasta_fields = "strain virus accession collection_date region country division location host domestic_status subtype originating_lab submitting_lab authors PMID gisaid_clade h5_clade",
         output_dir = lambda wildcards, output: Path(output.sequences).parent,
         output_fstem = lambda wildcards, output: Path(output.sequences).stem,
+        path_to_fauna = path_to_fauna
     benchmark:
         "fauna/benchmarks/download_segment_{segment}.txt"
     shell:
         """
-        python3 {path_to_fauna}/vdb/download.py \
+        python3 {params.path_to_fauna:q}/vdb/download.py \
             --database vdb \
             --virus avian_flu \
             --fasta_fields {params.fasta_fields} \


### PR DESCRIPTION
The current value expects fauna to be a sister directory to 'ingest'. This is valid when we are using the docker runtime¹ as it mounts the 'ingest' folder to '/nextstrain/build' and fauna is 'nextstrain/fauna', but it almost never true when running outside of docker as that would require fauna to be within the 'avian-flu' repo. The docs do state that we must run in docker, but that's an overly strict requirement.

Addition context on slack <https://bedfordlab.slack.com/archives/CD84ELG0N/p1723666776588239?thread_ts=1720569955.202459&cid=CD84ELG0N>

¹ until we add a nextstrain-pathogen.yaml file


- [ ] Checks pass