### PR TITLE
add nextstrain-pathogen.yaml

### DIFF
--- a/ingest/README.md
+++ b/ingest/README.md
@@ -86,10 +86,8 @@ nextstrain build \
 This command produces one metadata file, `fauna/results/metadata.tsv`, and one sequences file per gene segment like `fauna/results/sequences_ha.fasta`.
 Each file represents all available subtypes.
 
-> If you are running this outside of Docker you'll need to define the location of fauna via the `path_to_fauna` config option.
-  The path is relative to the 'ingest' directory.
-  Adding `--config path_to_fauna="../../fauna"` works if your fauna directory is a sister directory to the avian-flu repo itself, which is a common set up.
-  
+> If you are running this outside of Docker we expect 'fauna' to be a sister directory to 'avian-flu'.
+  You can change this via `--config path_to_fauna=<path>` where the path is relative to the 'ingest' directory.
 
 Add the `upload_all` target to the command above to run the complete ingest pipeline _and_ upload results to AWS S3.
 The workflow compresses and uploads the local files to S3 to corresponding paths like `s3://nextstrain-data-private/files/workflows/avian-flu/metadata.tsv.zst` and `s3://nextstrain-data-private/files/workflows/avian-flu/ha/sequences.fasta.zst`.

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -11,4 +11,4 @@ segments:
 s3_dst:
   fauna: s3://nextstrain-data-private/files/workflows/avian-flu
 
-path_to_fauna: ../fauna
+path_to_fauna: ../../fauna


### PR DESCRIPTION
This results in a different mount point for the 'ingest' directory in docker runtimes which more closely matches a typical setup using other runtimes. This allows the relative location of fauna ('path_to_fauna') to be the same for a typical ambient setup as for docker.

See <https://github.com/nextstrain/cli/issues/371#issuecomment-2299670219> for more detail on mount points for the docker runtime.

@joverlee521 / @tsibley are there any additional side-effects of `nextstrain-pathogen.yaml` I'm not aware of?

- [x] trial fauna ingest action [successfully completed](https://github.com/nextstrain/avian-flu/actions/runs/10479808612)
- [x] Checks pass
