### PR TITLE
Dedup ncbi

### DIFF
--- a/ingest/build-configs/ncbi/bin/dedup-by-sample-id
+++ b/ingest/build-configs/ncbi/bin/dedup-by-sample-id
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""
+Deduplicate records by the sample id of the `strain` field.
+
+For example, the following strain names have duplicate sample id 24-005334-001
+- A/chicken/Ohio/24-005334-001/2024
+- A/Chicken/USA/24-005334-001-original/2024
+
+Only keeps the first record of duplicates and keeps record if the sample id
+cannot be parsed from `strain`.
+"""
+import json
+import re
+from sys import stderr, stdin, stdout
+
+
+SAMPLE_ID_REGEX = r"^A\/[^\/]*\/[^\/]*\/(\d{2}-\d{6}-\d{3})[^\/]*\/\d{4}$"
+STRAIN_FIELD = "strain"
+
+
+if __name__ == "__main__":
+    seen_sample_ids = set()
+
+    for index, record in enumerate(stdin):
+        record = json.loads(record).copy()
+
+        strain = record[STRAIN_FIELD]
+        sample_id_matches = re.match(SAMPLE_ID_REGEX, strain)
+        if sample_id_matches is not None:
+            sample_id = sample_id_matches.group(1)
+            if sample_id in seen_sample_ids:
+                print(
+                    f"Dropping record {index!r} because it has a duplicate ",
+                    f"sample ID {sample_id!r} in the strain name {strain!r}",
+                    file=stderr
+                )
+                continue
+
+            seen_sample_ids.add(sample_id)
+
+        # Not every strain name has a matching sample id
+        # Just keep records that don't match
+        json.dump(record, stdout, allow_nan=False, indent=None, separators=',:')
+        print()

--- a/ingest/build-configs/ncbi/rules/curate.smk
+++ b/ingest/build-configs/ncbi/rules/curate.smk
@@ -123,11 +123,12 @@ rule split_curated_ndjson_by_segment:
     benchmark:
         "ncbi/benchmarks/{segment}/split_curated_ndjson_by_segment.txt"
     shell:
-        """
+        r"""
         (cat {input.curated_ndjson} \
             | ./build-configs/ncbi/bin/filter-ndjson-by-segment \
                 --segment {wildcards.segment} \
             | ./build-configs/ncbi/bin/dedup-by-strain \
+            | ./build-configs/ncbi/bin/dedup-by-sample-id \
             | augur curate passthru \
                 --output-metadata {output.metadata} \
                 --output-fasta {output.sequences} \

--- a/ingest/build-configs/ncbi/rules/ingest_andersen_lab.smk
+++ b/ingest/build-configs/ncbi/rules/ingest_andersen_lab.smk
@@ -127,11 +127,12 @@ rule curate_metadata:
         expected_date_formats=['%Y-%m-%d', '%Y', '%Y-%m-%d %H:%M:%S', '%Y-%m-%dT%H:%M:%SZ'],
         annotations_id=config["curate"]["annotations_id"],
     shell:
-        """
-        augur curate normalize-strings \
+        r"""
+        (augur curate normalize-strings \
             --metadata {input.metadata} \
             | ./build-configs/ncbi/bin/curate-andersen-lab-data \
             | ./build-configs/ncbi/bin/dedup-by-strain \
+            | ./build-configs/ncbi/bin/dedup-by-sample-id \
             | augur curate format-dates \
                 --date-fields {params.date_fields:q} \
                 --expected-date-formats {params.expected_date_formats:q} \
@@ -143,7 +144,7 @@ rule curate_metadata:
                 --annotations {input.annotations} \
                 --id-field {params.annotations_id} \
             | augur curate passthru \
-                --output-metadata {output.metadata} 2>> {log}
+                --output-metadata {output.metadata}) 2>> {log}
         """
 
 rule match_metadata_and_segment_fasta:


### PR DESCRIPTION
## Description of proposed changes

Dedup the records by sample id within the strain name of GenBank/Andersen lab records. 

For example, the following strain names have duplicate sample id `24-005334-001`
- A/chicken/Ohio/24-005334-001/2024
- A/Chicken/USA/24-005334-001-original/2024

Only keeps the first record of duplicates. When there are dups _within_ a data source, the earliest released record is kept. When there are dups between GenBank and Andersen lab records, the GenBank record is kept. 


## Related issue(s)

Resolves <https://github.com/nextstrain/avian-flu/issues/95>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Trial run](https://github.com/nextstrain/avian-flu/actions/runs/11332064771)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
