### PR TITLE
[h5n1-cattle-outbreak] show timetree for genome build

### DIFF
--- a/config/h5n1-cattle-outbreak/auspice_config_h5n1-cattle-outbreak.json
+++ b/config/h5n1-cattle-outbreak/auspice_config_h5n1-cattle-outbreak.json
@@ -124,7 +124,7 @@
     "map_triplicate": false,
     "color_by": "host",
     "geo_resolution": "division",
-    "distance_measure": "div"
+    "distance_measure": "__VALUE_OVERWRITTEN_BY_SNAKEMAKE_PIPELINE__"
   },
   "filters": [
     "host",


### PR DESCRIPTION
Resolves #94

Tested by building all h5n1-cattle-outbreak trees (n=9) locally.