### PR TITLE
[ingest/ncbi] Update host-map

### DIFF
--- a/ingest/build-configs/ncbi/defaults/host-map.tsv
+++ b/ingest/build-configs/ncbi/defaults/host-map.tsv
@@ -80,6 +80,7 @@ red fox	Nonhuman Mammal
 red tailed hawk	Avian
 skunk	Nonhuman Mammal
 snow goose	Avian
+Streptopelia decaocto	Avian
 Turdus merula	Avian
 turkey	Avian
 turkey vulture	Avian


### PR DESCRIPTION
Strain A/EurasianCollaredDove/CO/24-021011-001-original/2024 had a host of Streptopelia decaocto (Eurasian collared dove)