### PR TITLE
Cattle outbreak clock filter

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -203,7 +203,9 @@ def refine_clock_rates(w):
     return f"--clock-rate {info[w.segment][0]} --clock-std-dev {info[w.segment][1]}"
 
 def refine_clock_filter(w):
-    filter = get_config('refine', 'clock_filter_iqd', w)
+    filter = get_config('refine', 'genome_clock_filter_iqd', w) \
+        if w.segment=='genome' \
+        else get_config('refine', 'clock_filter_iqd', w)
     return f"--clock-filter-iqd {filter}" if filter else ""
 
 

--- a/config/h5n1-cattle-outbreak.yaml
+++ b/config/h5n1-cattle-outbreak.yaml
@@ -75,6 +75,8 @@ refine:
   coalescent: const
   date_inference: marginal
 
+  genome_clock_filter_iqd:
+    FALLBACK: 3
   clock_filter_iqd:
     FALLBACK: false
 

--- a/ingest/build-configs/ncbi/defaults/host-map.tsv
+++ b/ingest/build-configs/ncbi/defaults/host-map.tsv
@@ -92,3 +92,6 @@ western sandpiper	Avian
 Wild-Bird	Avian
 EMU	Avian
 Emu	Avian
+Dromaius novaehollandiae	Avian
+White-winged Dove	Avian
+Rock Pigeon	Avian


### PR DESCRIPTION
This should help remove outliers unrelated to the cattle-outbreak,
especially as the clock signal is worse than it might otherwise be for
these outliers due to our enforcing of the root strain.

Also includes some host fixes

Builds up on staging (e.g. [genome](https://next.nextstrain.org/staging/avian-flu/h5n1-cattle-outbreak/genome)) but these don't include the host fixes as I didn't run ingest locally. 

P.S. These changes, were they to be implemented on top of #104, are much nicer:

```diff
-   clock_filter_iqd: false
+   clock_filter_iqd:
+     "*/genome/*": 3
+     "*/*/*": false
```