### PR TITLE
h5n1-cattle-outbreak: loosen genome_clock_filter_iqd

### DIFF
--- a/config/h5n1-cattle-outbreak.yaml
+++ b/config/h5n1-cattle-outbreak.yaml
@@ -76,7 +76,7 @@ refine:
   date_inference: marginal
 
   genome_clock_filter_iqd:
-    FALLBACK: 3
+    FALLBACK: 6
   clock_filter_iqd:
     FALLBACK: false
 
@@ -130,7 +130,7 @@ traits:
     FALLBACK: false
 
   # all builds
-  confidence: 
+  confidence:
     FALLBACK: true
 
 export:


### PR DESCRIPTION
## Description of proposed changes
Loosening the genome_clock_filter_iqd because the important human sequences have been filtered out by the clock filter in the latest builds.

<https://bedfordlab.slack.com/archives/CD84ELG0N/p1735438616520059>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Trial run](https://github.com/nextstrain/avian-flu/actions/runs/12563969278)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
