### PR TITLE
ingest/ncbi: Replace "invalid" characters from `strain`

### DIFF
--- a/ingest/build-configs/ncbi/bin/transform-to-match-fauna
+++ b/ingest/build-configs/ncbi/bin/transform-to-match-fauna
@@ -4,6 +4,7 @@ Transforms to specific fields in the NDJSON record to match the output
 metdata from fauna for easier downstream use in the phylogenetic workflow
 """
 import json
+import re
 from sys import stdin, stdout
 
 
@@ -31,7 +32,12 @@ if __name__ == "__main__":
         # Keep a copy of the original strain name since we are editing it below
         record["original_strain"] = record["strain"]
         # Remove spaces from strain names since they are not allowed in our phylo workflow.
-        record["strain"] = record["original_strain"].replace(" ", "")
+        # Replace invalid characters with `_` to match iqtree so augur tree will not modify strain
+        # <https://github.com/iqtree/iqtree2/blob/74da454bbd98d6ecb8cb955975a50de59785fbde/utils/tools.cpp#L607>
+        # Similar to the changes made for the curate-andersen-lab-data script in
+        # <https://github.com/nextstrain/avian-flu/commit/b6f9b561afc4e73e8f3a14c4925aa874325f04d9>.
+        strain = record["original_strain"].replace(" ", "")
+        record["strain"] = re.sub(r'[^\w\_\-\.\|\/]', '_', strain)
 
         json.dump(record, stdout, allow_nan=False, indent=None, separators=',:')
         print()


### PR DESCRIPTION
## Description of proposed changes

Replace what iqtree considers "invalid" characters with "_" in `strain` so that augur tree/iqtree does not change the strain name in the phylogenetic workflow and cause an error in augur refine.

Similar to the changes made for the curate-andersen-lab-data script in <https://github.com/nextstrain/avian-flu/commit/b6f9b561afc4e73e8f3a14c4925aa874325f04d9>.

## Related issue(s)

Resolves https://github.com/nextstrain/avian-flu/issues/122

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Trial run](https://github.com/nextstrain/avian-flu/actions/runs/13206823539)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
