### PR TITLE
[bugfix add-clades.py] preserve columns

### DIFF
--- a/clade-labeling/add-clades.py
+++ b/clade-labeling/add-clades.py
@@ -48,7 +48,7 @@ def annotate_metadata_file(metadata_infile, metadata_outfile, clade_assignments)
 		for line in infile:
 			linecount += 1
 			if linecount == 1:
-				new_line = line.strip() + "\th5_label_clade\n"
+				new_line = line.rstrip("\n") + "\th5_label_clade\n"
 			else:
 				strain_name = line.split("\t")[0]
 				if strain_name in clade_assignments:
@@ -58,7 +58,7 @@ def annotate_metadata_file(metadata_infile, metadata_outfile, clade_assignments)
 					clade = "?"
 					unknown_clades += 1
 					#print("unknown clade for ", strain_name)
-				new_line = line.strip() + "\t" + clade + "\n"
+				new_line = line.rstrip("\n") + "\t" + clade + "\n"
 		
 			with open(metadata_outfile, "a") as outfile:
 				outfile.write(new_line)


### PR DESCRIPTION
If a line in the input TSV had trailing blank columns, i.e. trailing tab characters, these would be removed by `line.strip()` and the resulting output TSV would have an inconsistent number of columns.

Going to merge this ASAP as it was discovered while testing #127 