### PR TITLE
GenoFLU for fauna datasets

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -652,6 +652,15 @@ rule auspice_config:
                 auspice_config['colorings'][division_idx]["title"] += " (inferred)"
             else:
                 auspice_config['display_defaults']['distance_measure'] = "div"
+        
+        # If we have a coloring for 'genoflu' and we're not a genome build then export the genoflu call for the segment
+        genoflu_idx = next((i for i,c in enumerate(auspice_config['colorings']) if c['key']=='genoflu'), None)
+        if wildcards.segment!='genome' and genoflu_idx is not None:
+            auspice_config['colorings'].insert(genoflu_idx+1, {
+                    "key": f"genoflu_{wildcards.segment.upper()}",
+                    "title": f"GenoFLU ({wildcards.segment.upper()} segment)",
+                    "type": "categorical",
+                })
         with open(output.auspice_config, 'w') as fh:
             json.dump(auspice_config, fh, indent=2)
 

--- a/config/h5n1/auspice_config_h5n1.json
+++ b/config/h5n1/auspice_config_h5n1.json
@@ -61,6 +61,11 @@
       "type": "categorical"
     },
     {
+      "key": "genoflu",
+      "title": "GenoFLU constellation",
+      "type": "categorical"
+    },
+    {
       "key": "gisaid_clade",
       "title": "GISAID Clade",
       "type": "categorical"

--- a/config/h5nx/auspice_config_h5nx.json
+++ b/config/h5nx/auspice_config_h5nx.json
@@ -61,6 +61,11 @@
       "type": "categorical"
     },
     {
+      "key": "genoflu",
+      "title": "GenoFLU constellation",
+      "type": "categorical"
+    },
+    {
       "key": "gisaid_clade",
       "title": "GISAID Clade",
       "type": "categorical"

--- a/config/h7n9/auspice_config_h7n9.json
+++ b/config/h7n9/auspice_config_h7n9.json
@@ -36,6 +36,11 @@
       "type": "categorical"
     },
     {
+      "key": "genoflu",
+      "title": "GenoFLU constellation",
+      "type": "categorical"
+    },
+    {
       "key": "furin_cleavage_motif",
       "title": "Furin Cleavage Motif",
       "type": "categorical"

--- a/config/h9n2/auspice_config_h9n2.json
+++ b/config/h9n2/auspice_config_h9n2.json
@@ -36,6 +36,11 @@
       "type": "categorical"
     },
     {
+      "key": "genoflu",
+      "title": "GenoFLU constellation",
+      "type": "categorical"
+    },
+    {
       "key": "furin_cleavage_motif",
       "title": "Furin Cleavage Motif",
       "type": "categorical"

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -14,4 +14,4 @@ s3_dst:
 path_to_fauna: ../../fauna
 
 genoflu:
-  fauna: false
+  fauna: true

--- a/ingest/rules/genoflu.smk
+++ b/ingest/rules/genoflu.smk
@@ -58,11 +58,8 @@ rule parse_genoflu:
         r"""
         cat {input.genoflu} | \
             csvtk cut -t -F -f Strain,Genotype,'Genotype List Used*' | \
-            csvtk grep -t -F -f 'Genotype List Used*' -r -p "^PA:.+HA:.+PB1:.+MP:.+NA:.+PB2:.+NP:.+NS:.+$" -N | \
-            csvtk sep -t -n genoflu_PA,genoflu_HA,genoflu_PB1,genoflu_MP,genoflu_NA,genoflu_PB2,genoflu_NP,genoflu_NS -f 3 -s ", "  | \
-            csvtk replace -t -f 4-11 -p "^(.+):" | \
-            csvtk cut -t -f 1,2,4-11 | \
-            csvtk rename -t -f Strain,Genotype -n strain,genoflu \
+            csvtk rename -t -F -f Strain,Genotype,'Genotype List Used*' -n strain,genoflu,details | \
+            python scripts/parse_genoflu.py \
             > {output.genotypes}
         """
 

--- a/ingest/scripts/parse_genoflu.py
+++ b/ingest/scripts/parse_genoflu.py
@@ -1,0 +1,30 @@
+"""
+Takes a (modified) GenoFLU results TSV on STDIN and writes a TSV to STDOUT
+The input TSV is expected to have three fields:
+* strain
+* genoflu
+* details
+The output TSV exports 10 fields:
+* strain
+* genoflu
+* genoflu_<SEGMENT> (8 fields)
+"""
+
+
+from augur.io.metadata import read_table_to_dict
+from sys import stdin, stdout
+from csv import DictWriter
+
+if __name__ == "__main__":
+    SEGMENTS = ["PB2", "PB1", "PA", "HA", "NP", "NA", "MP", "NS"]
+    HEADER = ['strain', 'genoflu', *[f"genoflu_{s}" for s in SEGMENTS]]
+    tsv_writer = DictWriter(stdout,HEADER,extrasaction='ignore',delimiter='\t',lineterminator='\n')
+    tsv_writer.writeheader()
+    for record in read_table_to_dict(stdin.buffer, ["\t"]):
+        if record['details']:
+            for segment_name, lineage in (parts.split(':') for parts in record['details'].split(", ")):
+                record[f"genoflu_{segment_name}"] = lineage
+        # Collapse all "not assigned" calls into a single metadata value
+        if record['genoflu'].startswith("Not assigned:"):
+            record['genoflu'] = "Not assigned (too divergent)"
+        tsv_writer.writerow(record)


### PR DESCRIPTION
Generates and exports both the per-segment GenoFLU results and the whole-genome genotype/constellation.

There's a few outstanding to-dos, to be done either here or elsewhere:

- [ ] If there are fewer than 8 segments then genoflu doesn't report this in the results (or the log). We already have `n_segments` in the metadata so we could use this to generate a "<8 segments sequenced" label if desired.
- [ ] What's more frustrating for samples with fewer than 8 segments is that we don't get the per-segment calls for the sequenced segments. Presumably we could modify genoflu to report these. 
- [x] For genomes where some of the segments are too diverged my current parsing approach doesn't pull them out. While it was fun to do everything in `csvtk` we should switch to a python script to correctly parse annotations where (e.g.) the genotype list is `MP:ea3, HA:ea3, NA:ea5, PB1:ea3` and the genotype is `Not assigned: Only 4 segments >98.0% match found of total 8 segments in input file`