### PR TITLE
Limit ambiguous dates by sample release date

### DIFF
--- a/ingest/build-configs/ncbi/rules/ingest_andersen_lab.smk
+++ b/ingest/build-configs/ncbi/rules/ingest_andersen_lab.smk
@@ -124,6 +124,8 @@ rule curate_metadata:
     params:
         host_map=config["curate"]["host_map"],
         date_fields=['date', 'date_released'],
+        target_date_field='date',
+        target_date_field_max='date_released',
         expected_date_formats=['%Y-%m-%d', '%Y', '%Y-%m-%d %H:%M:%S', '%Y-%m-%dT%H:%M:%SZ'],
         annotations_id=config["curate"]["annotations_id"],
     shell:
@@ -136,6 +138,8 @@ rule curate_metadata:
             | augur curate format-dates \
                 --date-fields {params.date_fields:q} \
                 --expected-date-formats {params.expected_date_formats:q} \
+                --target-date-field {params.target_date_field:q} \
+                --target-date-field-max {params.target_date_field_max:q} \
             | ./build-configs/ncbi/bin/transform-host \
                 --host-map {params.host_map} \
             | ./vendored/apply-geolocation-rules \


### PR DESCRIPTION
## Description of proposed changes

Limit year-only dates using upcoming precise date support in Augur (https://github.com/nextstrain/augur/issues/1494)

Example:

![curate output](https://github.com/user-attachments/assets/77561ec2-2d47-4474-9d31-1ef1a044472c)

<!-- What is the goal of this pull request? What does this pull request change? -->

## Related issue(s)

- Depends on https://github.com/nextstrain/augur/issues/1494

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Add a column for `--target-date-field-min`?
- [ ] Do the same for NCBI Datasets data?
- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
