### PR TITLE
ingest/ncbi: Add `retries` for rules that fetch data

### DIFF
--- a/ingest/build-configs/ncbi/rules/fetch_from_ncbi.smk
+++ b/ingest/build-configs/ncbi/rules/fetch_from_ncbi.smk
@@ -31,6 +31,8 @@ rule fetch_from_ncbi_virus:
         ncbi_taxon_id=config["ncbi_taxon_id"],
         ncbi_collection_date_filter=_get_date_filter(),
         ncbi_virus_filters=" ".join(f"{filter!r}" for filter in config["ncbi_virus_filters"]),
+    # Allow retries in case of network errors
+    retries: 5
     shell:
         """
         ./build-configs/ncbi/bin/fetch-from-ncbi-virus \

--- a/ingest/build-configs/ncbi/rules/ingest_andersen_lab.smk
+++ b/ingest/build-configs/ncbi/rules/ingest_andersen_lab.smk
@@ -7,6 +7,8 @@ from the Andersen Lab's avian-influenza repo
 rule fetch_andersen_lab_repo:
     output:
         andersen_lab_repo = temp("andersen-lab/data/avian-influenza.tar.gz")
+    # Allow retries in case of network errors
+    retries: 5
     shell:
         """
         curl -fsSL \


### PR DESCRIPTION
## Description of proposed changes

Allow rules that fetch data to retry in case of network errors. Allow 5 retries, which is the usual number we use for the  `fetch_ncbi_dataset_package` rule across ingest workflows.¹

Resolves https://github.com/nextstrain/avian-flu/issues/154

¹ <https://github.com/nextstrain/pathogen-repo-guide/blob/a227dc9485b0291f0d0848168d81a48e15e600ac/ingest/rules/fetch_from_ncbi.smk#L44-L45>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
