### PR TITLE
Run GenoFlu on all-influenza curated data

### DIFF
--- a/.github/workflows/genoflu-gisaid.yaml
+++ b/.github/workflows/genoflu-gisaid.yaml
@@ -1,7 +1,78 @@
-# this workflow is a stub action to allow testing from a branch
-
 name: Run GenoFLU on curated GISAID data
 
+defaults:
+  run:
+    # This is the same as GitHub Action's `bash` keyword as of 20 June 2023:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    #
+    # Completely spelling it out here so that GitHub can't change it out from under us
+    # and we don't have to refer to the docs to know the expected behavior.
+    shell: bash --noprofile --norc -eo pipefail {0}
+
 on:
+  workflow_call:
+    inputs:
+      image:
+        description: 'Specific container image to use for ingest workflow (will override the default of "nextstrain build")'
+        required: false
+        type: string
+
   workflow_dispatch:
-    
+    inputs:
+      image:
+        description: 'Specific container image to use for ingest workflow (will override the default of "nextstrain build")'
+        required: false
+        type: string
+      trial-name:
+        description: |
+          Trial name for outputs.
+          If not set, outputs will overwrite files at s3://nextstrain-data/files/workflows/avian-flu/
+          If set, outputs will be uploaded to s3://nextstrain-data/files/workflows/avian-flu/trials/<trial_name>/
+        required: false
+        type: string
+
+  # Expose a repository dispatch so that we can trigger this workflow when the all-influenza
+  # curation pipeline has finished (currently via the seasonal-flu repo)
+  repository_dispatch:
+    types:
+      - genoflu-gisaid
+
+jobs:
+  ingest:
+    permissions:
+      id-token: write
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    secrets: inherit
+    with:
+      # Starting with the default docker runtime
+      # We can migrate to AWS Batch when/if we need to for more resources or if
+      # the job runs longer than the GH Action limit of 6 hours.
+      runtime: docker
+      run: |
+        declare -a config;
+
+        if [[ "$TRIAL_NAME" ]]; then
+          # Create JSON string for the nested upload config
+          S3_DST="s3://nextstrain-data-private/files/workflows/avian-flu/trial/$TRIAL_NAME"
+          config+=(
+            s3_dst=$(jq -cn --arg S3_DST "$S3_DST" '{"gisaid": $S3_DST}')
+          )
+        fi;
+
+        nextstrain build \
+          ingest \
+            --snakefile gisaid/Snakefile \
+            upload_all \
+            --config "${config[@]}"
+      env: |
+        NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
+        TRIAL_NAME: ${{ inputs.trial-name }}
+      # Explicitly excluding `ingest/gisaid/results` and `ingest/gisaid/data`
+      # since this is private data and should not available through the public artifacts
+      artifact-name: genoflu-gisaid
+      artifact-paths: |
+        ingest/.snakemake/log/
+        ingest/gisaid/logs/
+        ingest/gisaid/benchmarks/
+        !ingest/gisaid/results
+        !ingest/gisaid/data

--- a/.github/workflows/genoflu-gisaid.yaml
+++ b/.github/workflows/genoflu-gisaid.yaml
@@ -23,19 +23,13 @@ on:
         description: 'Specific container image to use for ingest workflow (will override the default of "nextstrain build")'
         required: false
         type: string
-      trial-name:
+      trial_name:
         description: |
           Trial name for outputs.
           If not set, outputs will overwrite files at s3://nextstrain-data/files/workflows/avian-flu/
-          If set, outputs will be uploaded to s3://nextstrain-data/files/workflows/avian-flu/trials/<trial_name>/
+          If set, outputs will be uploaded to s3://nextstrain-data/files/workflows/avian-flu/trial/<trial_name>/
         required: false
         type: string
-
-  # Expose a repository dispatch so that we can trigger this workflow when the all-influenza
-  # curation pipeline has finished (currently via the seasonal-flu repo)
-  repository_dispatch:
-    types:
-      - genoflu-gisaid
 
 jobs:
   ingest:
@@ -66,7 +60,7 @@ jobs:
             --config "${config[@]}"
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.image }}
-        TRIAL_NAME: ${{ inputs.trial-name }}
+        TRIAL_NAME: ${{ inputs.trial_name }}
       # Explicitly excluding `ingest/gisaid/results` and `ingest/gisaid/data`
       # since this is private data and should not available through the public artifacts
       artifact-name: genoflu-gisaid

--- a/ingest/gisaid/README.md
+++ b/ingest/gisaid/README.md
@@ -1,0 +1,18 @@
+This directory represents the workflow which takes curated data (TSV + FASTAs) from our all-influenza curation pipeline (part of the seasonal-flu repo) and adds in GenoFLU metadata, and then uploads the (new) metadata and (unchanged) sequences to S3.
+
+See the sister `config.yaml` for the S3 addresses.
+
+**GitHub action**
+
+The `genoflu-gisaid` GitHub action runs this workflow.
+The intention is for the seasonal-flu repo to trigger it when newly curated data are available.
+
+**Maual usage**
+
+Working directory: `avian-flu/ingest`
+
+Command: `snakemake --cores 1 --snakefile gisaid/Snakefile -npf`
+
+Add `upload_all` to the end of that rule if you also want to upload files.
+
+

--- a/ingest/gisaid/Snakefile
+++ b/ingest/gisaid/Snakefile
@@ -1,0 +1,56 @@
+
+import os
+configfile: os.path.join(workflow.basedir, "config.yaml")
+
+include: "../../shared/vendored/snakemake/remote_files.smk"
+include: "../rules/genoflu.smk"
+include: "../rules/upload_to_s3.smk"
+
+
+# The Genoflu workflow will create "gisaid/results/metadata.tsv" with GenoFLU information
+# So make that the default workflow target. This will force provisioning of upstream
+# metadata & sequences
+rule all:
+    input:
+        metadata="gisaid/results/metadata.tsv",
+
+rule upload_all:
+    input:
+        metadata="gisaid/s3/metadata.done",
+        sequences=expand("gisaid/s3/sequences_{segment}.done", segment=config["segments"]),
+
+rule get_sequence:
+    """
+    Provisions the curated sequences (ultimately from the seasonal-flu ingest)
+    into the location where both the GenoFlu workflow and the upload rules can access them.
+    (Note: We could use a different location and skip `provision_genoflu_sequences` but
+    we want to upload the sequences at the end of the workflow in order to keep metadata
+    & sequences in-sync.)
+    """
+    input:
+        path_or_url(config['sequences'])
+    output:
+        "gisaid/results/sequences_{segment}.fasta"
+    shell:
+        """
+        if [[ {input[0]} == *.xz ]]; then
+            xz -dc {input[0]} > {output[0]}
+        elif [[ {input[0]} == *.zst ]]; then
+            zstd -dc {input[0]} > {output[0]}
+        else
+            cp {input[0]} {output[0]}
+        fi
+        """
+
+rule get_metadata:
+    """
+    Provisions the metadata in the location the genoflu workflow expects it.
+    """
+    input:
+        path_or_url(config['metadata'])
+    output:
+        "gisaid/data/metadata_combined.tsv"
+    shell:
+        """
+        cp {input[0]} {output[0]}
+        """

--- a/ingest/gisaid/config.yaml
+++ b/ingest/gisaid/config.yaml
@@ -1,0 +1,18 @@
+
+# Download files from:
+# TODO XXX - change when we take the seasonal-flu outputs out of "trials" mode
+sequences: s3://nextstrain-data-private/files/workflows/seasonal-flu/trials/ingest/avian-flu/{segment}/sequences.fasta.xz
+metadata: s3://nextstrain-data-private/files/workflows/seasonal-flu/trials/ingest/avian-flu/metadata.tsv.xz
+# Note: replace the above with (e.g.) "../../seasonal-flu/ingest/results/avian-flu/{segment}.fasta" for local usage, as needed
+
+# Upload data to:
+s3_dst:
+  # NOTE: the intention is to overwrite this for testing purposes via the API call
+  # In case that doesn't work, I set a conservative trial prefix to ensure we don't overwrite canonical files
+  # TODO XXX - change to files/workflows/avian-flu
+  gisaid: s3://nextstrain-data-private/files/workflows/avian-flu/trial/genoflu-gisaid-should-not-be-used
+
+segments: ["pb2", "pb1", "pa", "ha", "np", "na", "mp", "ns"]
+
+genoflu:
+  gisaid: true

--- a/ingest/vendored-GenoFLU-multi/bin/genoflu-multi.py
+++ b/ingest/vendored-GenoFLU-multi/bin/genoflu-multi.py
@@ -7,6 +7,7 @@ import shutil
 import argparse
 import time
 import multiprocessing as mp
+from sys import stderr
 
 def split(l, n):
     k, m = divmod(len(l), min(n, len(l)))
@@ -22,7 +23,13 @@ def run_genoflu(strain_records, core = None):
     
     temp_fasta = os.path.join(temp_dir, 'temp.fasta')
     
+    progress_count = 0
+    num_records = len(strain_records)
+
     for strain, records in strain_records:
+        progress_count+=1
+        if progress_count%100==0:
+            print(f"CORE {core} || Running {progress_count:,}/{num_records:,} ({int(progress_count*100.0/num_records)}%)", file=stderr)
         i = 1
         # append sequential numbers to end of record ids to prevent duplicate key error
         for record in records:
@@ -191,7 +198,7 @@ if __name__ == '__main__':
     
         ## start multiprocessing pool
         mp.set_start_method('fork')
-        pool = mp.Pool()
+        pool = mp.Pool(cores)
     
         ## and run the simulations
         pool_data = pool.starmap(run_genoflu, zip(split_strain_records, range(1,cores+1)))


### PR DESCRIPTION
The ongoing work in seasonal-flu is leading us towards an all-influenza curation pipeline. Specifically, https://github.com/nextstrain/seasonal-flu/pull/270 will produce a curated set of avian-flu subtypes. The remaining piece of information needed for avian-flu phylo builds is the GenoFLU metadata. The Snakefile added here does just that and then uploads the data. The intention is for the all-influenza pipeline to trigger this workflow as required.

See config.yaml (added here) and API trigger (below) for S3 paths

Tested using the following API trigger, which is (similar to) how I expect the seasonal-flu repo to trigger it when newly curated data are available:

```console
$ curl -X POST   -H "Accept: application/vnd.github+json"  \
  -H "Authorization: Bearer $(gh auth token)"   \
   https://api.github.com/repos/nextstrain/avian-flu/actions/workflows/genoflu-gisaid.yaml/dispatches \
   -d '{"ref": "james/seasonal-flu-ingest", "inputs": { "trial_name": "genoflu-gisaid"}}'
{
  "workflow_run_id": 20358065596,
  "run_url": "https://api.github.com/repos/nextstrain/avian-flu/actions/runs/20358065596",
  "html_url": "https://github.com/nextstrain/avian-flu/actions/runs/20358065596"
}
```