### PR TITLE
Add stub github action for testing

### DIFF
--- a/.github/workflows/genoflu-gisaid.yaml
+++ b/.github/workflows/genoflu-gisaid.yaml
@@ -1,0 +1,7 @@
+# this workflow is a stub action to allow testing from a branch
+
+name: Run GenoFLU on curated GISAID data
+
+on:
+  workflow_dispatch:
+    


### PR DESCRIPTION
Actual development will happen in
<https://github.com/nextstrain/avian-flu/pull/158> but for testing purposes we need some copy of the workflow on the master branch. (I know there's another way involving a deliberately broken workflow on a branch, but I can't find the specifics at the moment.)
