### PR TITLE
Register `nextstrain run` compatible workflows

### DIFF
--- a/nextstrain-pathogen.yaml
+++ b/nextstrain-pathogen.yaml
@@ -1,0 +1,16 @@
+# This file's *existence* marks the top level of a Nextstrain pathogen repo,
+# which allows `nextstrain build` to be run from any subdirectory of the repo
+# regardless of runtime.  For more details, see
+# <https://github.com/nextstrain/cli/releases/tag/8.2.0>.
+#
+# This file's *contents* is the "registration metadata" for the pathogen repo,
+# used by `nextstrain setup` and `nextstrain run`.
+---
+$schema: https://nextstrain.org/schemas/pathogen/v0
+workflows:
+  genome-focused:
+    compatibility:
+      nextstrain run: True
+  segment-focused:
+    compatibility:
+      nextstrain run: True


### PR DESCRIPTION
## Description of proposed changes

Discussion around [available pathogens](https://github.com/nextstrain/cli/issues/502) made me realize that this repo does not register the compatible workflows in `nextstrain-pathogen.yaml` yet. 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
