### PR TITLE
.github/ingest-to-phylo: Reduce to weekly runs

### DIFF
--- a/.github/workflows/ingest-to-phylogenetic-ncbi.yaml
+++ b/.github/workflows/ingest-to-phylogenetic-ncbi.yaml
@@ -29,7 +29,8 @@ on:
     # Runs at 5pm UTC (1pm EDT/10am PDT) since curation by NCBI happens on the East Coast.
     # We were running into invalid zip archive errors at 9am PDT, so hoping an hour
     # delay will lower the error frequency
-    - cron: '0 17 * * *'
+    # Only running once a week on Mondays to reduce AWS Batch costs.
+    - cron: '0 17 * * 1'
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION

## Description of proposed changes

Reduce to weekly runs to reduce AWS Batch costs as discussed in [Slack](https://bedfordlab.slack.com/archives/C7SDVPBLZ/p1780505535805939?thread_ts=1779768455.902969&cid=C7SDVPBLZ).

## Related issue(s)

Related to https://github.com/nextstrain/private/issues/243

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] ~Update changelog~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
